### PR TITLE
Fix failing `mvn clean install` failing due to `datanucleaus.txt` and…

### DIFF
--- a/exectck/src/main/java/org/apache/jdo/exectck/AbstractTCKMojo.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/AbstractTCKMojo.java
@@ -18,6 +18,7 @@ package org.apache.jdo.exectck;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Properties;
@@ -138,5 +139,15 @@ public abstract class AbstractTCKMojo extends AbstractMojo {
         File toFile = new File(buildDirectory + File.separator + "classes" +
                 File.separator + LOG4J2_CONFIGURATION);
         FileUtils.copyFile(fromFile, toFile);
+    }
+
+    protected void resetFileContent(String fileName) throws MojoExecutionException {
+        File file = new File(fileName);
+        // reset file content
+        try {
+            FileUtils.write(file, "", Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to reset file content: " + file.toURI());
+        }
     }
 }

--- a/exectck/src/main/java/org/apache/jdo/exectck/Enhance.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/Enhance.java
@@ -80,6 +80,9 @@ public class Enhance extends AbstractTCKMojo {
         idtypes = new HashSet<String>();
         PropertyUtils.string2Set(identitytypes, idtypes);
 
+        // Reset logfile content (may not be empty if previous run crashed)
+        resetFileContent(implLogFile);
+
         // Create directory for enhancer logs
         String enhanceLogsDirName = logsDirectory + File.separator + "enhanced";
         File enhancerLogsDir = new File(enhanceLogsDirName);

--- a/exectck/src/main/java/org/apache/jdo/exectck/Enhance.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/Enhance.java
@@ -242,7 +242,8 @@ public class Enhance extends AbstractTCKMojo {
             try {
                 File logFile = new File(implLogFile);
                 File testLogFile = new File(testLogFilename);
-                FileUtils.moveFile(logFile, testLogFile);
+                FileUtils.copyFile(logFile, testLogFile);
+                FileUtils.forceDeleteOnExit(logFile);
             } catch (Exception e) {
                 System.out.println(">> Error moving implementation log file: " +
                     e.getMessage());

--- a/exectck/src/main/java/org/apache/jdo/exectck/Enhance.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/Enhance.java
@@ -18,6 +18,7 @@
 package org.apache.jdo.exectck;
 
 import java.net.MalformedURLException;
+import java.nio.charset.Charset;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.FileUtils;
@@ -243,6 +244,8 @@ public class Enhance extends AbstractTCKMojo {
                 File logFile = new File(implLogFile);
                 File testLogFile = new File(testLogFilename);
                 FileUtils.copyFile(logFile, testLogFile);
+                // reset file content
+                FileUtils.write(logFile, "", Charset.defaultCharset());
                 FileUtils.forceDeleteOnExit(logFile);
             } catch (Exception e) {
                 System.out.println(">> Error moving implementation log file: " +

--- a/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
@@ -467,12 +467,12 @@ public class RunTCK extends AbstractTCKMojo {
         }
         // Remove log file
         try {
-            FileUtils.forceDelete(new File(implLogFile));
+            FileUtils.forceDeleteOnExit(new File(implLogFile));
         } catch (Exception e) {
             System.out.println(">> Error deleting log file: " + e.getMessage());
         }
         try {
-            FileUtils.forceDelete(new File(TCK_LOG_FILE));
+            FileUtils.forceDeleteOnExit(new File(TCK_LOG_FILE));
         } catch (Exception e) {
             System.out.println(">> Error deleting log file: " + e.getMessage());
         }

--- a/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
@@ -266,6 +266,10 @@ public class RunTCK extends AbstractTCKMojo {
             Logger.getLogger(RunTCK.class.getName()).log(Level.SEVERE, null, ex);
         }
 
+        // Reset logfile content (may not be empty if previous run crashed)
+        resetFileContent(implLogFile);
+        resetFileContent(TCK_LOG_FILE);
+
         int failureCount = 0;
         for (String db : dbs) {
             System.setProperty("jdo.tck.database", db);
@@ -434,8 +438,7 @@ public class RunTCK extends AbstractTCKMojo {
                     try {
                         File logFile = new File(implLogFile);
                         FileUtils.copyFile(logFile, new File(testLogFilename));
-                        // reset file content
-                        FileUtils.write(logFile, "", Charset.defaultCharset());
+                        resetFileContent(implLogFile);
                     } catch (Exception e) {
                         System.out.println(">> Error copying implementation log file: "
                                 + e.getMessage());
@@ -444,8 +447,7 @@ public class RunTCK extends AbstractTCKMojo {
                     try {
                         File logFile = new File(TCK_LOG_FILE);
                         FileUtils.copyFile(logFile, new File(tckLogFilename));
-                        // reset file content
-                        FileUtils.write(logFile, "", Charset.defaultCharset());
+                        resetFileContent(TCK_LOG_FILE);
                     } catch (Exception e) {
                         System.out.println(">> Error copying tck log file: "
                                 + e.getMessage());

--- a/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
@@ -15,13 +15,11 @@
  */
 package org.apache.jdo.exectck;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -436,6 +434,8 @@ public class RunTCK extends AbstractTCKMojo {
                     try {
                         File logFile = new File(implLogFile);
                         FileUtils.copyFile(logFile, new File(testLogFilename));
+                        // reset file content
+                        FileUtils.write(logFile, "", Charset.defaultCharset());
                     } catch (Exception e) {
                         System.out.println(">> Error copying implementation log file: "
                                 + e.getMessage());
@@ -444,6 +444,8 @@ public class RunTCK extends AbstractTCKMojo {
                     try {
                         File logFile = new File(TCK_LOG_FILE);
                         FileUtils.copyFile(logFile, new File(tckLogFilename));
+                        // reset file content
+                        FileUtils.write(logFile, "", Charset.defaultCharset());
                     } catch (Exception e) {
                         System.out.println(">> Error copying tck log file: "
                                 + e.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
                           </includes>
                       </fileset>
                   </filesets>
+                  <failOnError>false</failOnError>
               </configuration>
             </plugin>
             <plugin>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -126,6 +126,7 @@
                             </includes>
                         </fileset>
                     </filesets>
+                    <failOnError>false</failOnError>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Fix failing `mvn clean install` failing due to `datanucleaus.txt` and other log files' deletion failing while being locked.