### PR TITLE
JDO-790: Add a flag -Djdo.tck.skipJndi to exectck

### DIFF
--- a/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
@@ -19,7 +19,6 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -76,6 +75,12 @@ public class RunTCK extends AbstractTCKMojo {
      */
     @Parameter( property = "project.lib.ext.directory", defaultValue = "${basedir}/../lib/ext", required = true)
     private String extLibsDirectory;
+
+    /**
+     * To skip jndi PMF Tests set to true.
+     */
+    @Parameter( property = "jdo.tck.skipJndi", defaultValue = "false", required = true)
+    private boolean skipJndi;
 
     /**
      * Location of implementation log file.
@@ -213,6 +218,7 @@ public class RunTCK extends AbstractTCKMojo {
         propsString.add("-DResultPrinterClass=" + resultPrinterClass);
         propsString.add("-Dverbose=" + verbose);
         propsString.add("-Djdo.tck.cleanupaftertest=" + cleanupaftertest);
+        propsString.add("-Djdo.tck.skipJndi=" + skipJndi);
         propsString.add("-DPMFProperties=" + buildDirectory + File.separator
                 + "classes" + File.separator + pmfProperties);
         propsString.add("-DPMF2Properties=" + buildDirectory + File.separator
@@ -511,13 +517,11 @@ public class RunTCK extends AbstractTCKMojo {
                 try {
                     fromFile = fi.next();
                     fromFileName = fromFile.toString();
-//                    System.out.println("Copying " + fromFileName);
                     if ((startIdx = fromFileName.indexOf(idtype + File.separator)) > -1) {
                         // fully specified name of file (idtype + package + filename)
                         pkgName = fromFileName.substring(startIdx);
                         toFile = new File(cfgDirName + File.separator
                                 + pkgName);
-//                        System.out.println("Copy from source dir to " + toFile.toString());
                         FileUtils.copyFile(fromFile, toFile);
                     }
                 } catch (IOException ex) {

--- a/tck/src/main/java/org/apache/jdo/tck/JDO_Test.java
+++ b/tck/src/main/java/org/apache/jdo/tck/JDO_Test.java
@@ -183,12 +183,12 @@ public abstract class JDO_Test extends TestCase {
      * String indicating the type of identity used for the current test case.
      * The value is either "applicationidentity" or "datastoreidentity".
      */
-    protected final String identitytype = System.getProperty("jdo.tck.identitytype");
+    protected static final String IDENTITYTYPE = System.getProperty("jdo.tck.identitytype");
 
     /** 
      * String indicating the name of the schema for the current test.
      */
-    protected final String schemaname = System.getProperty("jdo.tck.schemaname");
+    protected static final String SCHEMANAME = System.getProperty("jdo.tck.schemaname");
 
     /** Name of the file containing the properties for the PMF. */
     protected static String PMFProperties = System.getProperty("PMFProperties");
@@ -197,15 +197,19 @@ public abstract class JDO_Test extends TestCase {
      * If false then test will not clean up data from database.
      * The default value is true.
      */
-    protected static boolean cleanupData = 
+    protected static final boolean CLEANUP_DATA =
        System.getProperty("jdo.tck.cleanupaftertest", "true").equalsIgnoreCase("true");
 
     /** Flag indicating whether to close the PMF after each test or not.
      * It defaults to false.
      */   
-    protected static final boolean closePMFAfterEachTest =
+    protected static final boolean CLOSE_PMF_AFTER_EACH_TEST =
         System.getProperty("jdo.tck.closePMFAfterEachTest", "false").equalsIgnoreCase("true");
-    
+
+    /** Flag indicating whether to skip JNDI related tests. */
+    protected static final boolean SKIP_JNDI =
+            System.getProperty("jdo.tck.skipJndi", "false").equalsIgnoreCase("true");
+
     /** The Properties object for the PersistenceManagerFactory. */
     protected static Properties PMFPropertiesObject;
 
@@ -362,7 +366,7 @@ public abstract class JDO_Test extends TestCase {
             pmf = null;
         
         try {
-            if (cleanupData) {
+            if (CLEANUP_DATA) {
                 localTearDown();
             }
         } 
@@ -370,7 +374,7 @@ public abstract class JDO_Test extends TestCase {
             setTearDownThrowable("localTearDown", t);
         }
         
-        if (closePMFAfterEachTest) {
+        if (CLOSE_PMF_AFTER_EACH_TEST) {
             try {
                 closePMF();
             }
@@ -1213,7 +1217,7 @@ public abstract class JDO_Test extends TestCase {
      * identity; <code>false</code> otherwise:
      */
     public boolean runsWithApplicationIdentity() {
-        return APPLICATION_IDENTITY.equals(identitytype);
+        return APPLICATION_IDENTITY.equals(IDENTITYTYPE);
     }
     
     /** 
@@ -1230,8 +1234,7 @@ public abstract class JDO_Test extends TestCase {
                 "Test " + testName + 
                 " was not run, because it is only applicable for identity type " + 
                 requiredIdentityType + 
-                ". The identity type of the current configuration is " +
-                identitytype);
+                ". The identity type of the current configuration is " + IDENTITYTYPE);
         }
     }
 

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/GetPMFByJNDILocation.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/GetPMFByJNDILocation.java
@@ -68,12 +68,22 @@ public class GetPMFByJNDILocation extends AbstractGetPMF {
 
     /** */
     public void testInvalidGetPMF() {
-        checkGetPMFWithInvalidProperties(ASSERTION_FAILED);
+        if (SKIP_JNDI) {
+            logger.debug(
+                "Skipped test GetPMFByJNDILocation.testInvalidGetPMF because of jdo.tck.skipJndi.");
+        } else {
+            checkGetPMFWithInvalidProperties(ASSERTION_FAILED);
+        }
     }
 
     /** */
     public void testValidGetPMF() {
-        checkGetPMFWithValidProperties();
+        if (SKIP_JNDI) {
+            logger.debug(
+                "Skipped test GetPMFByJNDILocation.testValidGetPMF because of jdo.tck.skipJndi.");
+        } else {
+            checkGetPMFWithValidProperties();
+        }
     }
 
     /** */

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/GetPMFByJNDILocationAndClassLoader.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/GetPMFByJNDILocationAndClassLoader.java
@@ -68,12 +68,22 @@ public class GetPMFByJNDILocationAndClassLoader extends AbstractGetPMF {
 
     /** */
     public void testInvalidGetPMF() {
-        checkGetPMFWithInvalidProperties(ASSERTION_FAILED);
+        if (SKIP_JNDI) {
+            logger.debug(
+                "Skipped test GetPMFByJNDILocationAndClassLoader.testInvalidGetPMF because of jdo.tck.skipJndi.");
+        } else {
+            checkGetPMFWithInvalidProperties(ASSERTION_FAILED);
+        }
     }
 
     /** */
     public void testValidGetPMF() {
-        checkGetPMFWithValidProperties();
+        if (SKIP_JNDI) {
+            logger.debug(
+                "Skipped test GetPMFByJNDILocationAndClassLoader.testValidGetPMF because of jdo.tck.skipJndi.");
+        } else {
+            checkGetPMFWithValidProperties();
+        }
     }
 
     /** */

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/JDOConfigListener.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/JDOConfigListener.java
@@ -79,7 +79,7 @@ public class JDOConfigListener extends JDO_Test {
          *   The value depends on identity type so can only be known at runtime.
          */
         if (isTestToBePerformed()) {
-            overrides.put("javax.jdo.mapping.Schema", schemaname);
+            overrides.put("javax.jdo.mapping.Schema", SCHEMANAME);
         }
     }
 

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/Jdoconfig.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/Jdoconfig.java
@@ -70,7 +70,7 @@ public class Jdoconfig extends JDO_Test {
          *   The value depends on identity type so can only be known at runtime.
          */
         if (isTestToBePerformed()) {
-            overrides.put("javax.jdo.mapping.Schema", schemaname);
+            overrides.put("javax.jdo.mapping.Schema", SCHEMANAME);
         }
     }
 

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/Persistence.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/Persistence.java
@@ -63,7 +63,7 @@ public class Persistence extends JDO_Test {
 
     /** */
     public void testGetPMFfromNamedPU() {
-        String name = "PUNamed_" + identitytype + "0";
+        String name = "PUNamed_" + IDENTITYTYPE + "0";
         pmf = JDOHelper.getPersistenceManagerFactory(name);
         assertEquals("Incorrect value for RestoreValues",
                 false, pmf.getRestoreValues());
@@ -72,7 +72,7 @@ public class Persistence extends JDO_Test {
 
     /** */
     public void testGetPMFfromNamedPUWithNullOverrides() {
-        String name = "PUNamed_" + identitytype + "0";
+        String name = "PUNamed_" + IDENTITYTYPE + "0";
         pmf = JDOHelper.getPersistenceManagerFactory(null, name);
         assertEquals("Incorrect value for RestoreValues",
                 false, pmf.getRestoreValues());
@@ -81,7 +81,7 @@ public class Persistence extends JDO_Test {
 
     /** */
     public void testGetPMFfromNamedPUWithEmptyOverrides() {
-        String name = "PUNamed_" + identitytype + "0";
+        String name = "PUNamed_" + IDENTITYTYPE + "0";
         Map overrides = new HashMap();
         pmf = JDOHelper.getPersistenceManagerFactory(overrides, name);
         assertEquals("Incorrect value for RestoreValues",
@@ -91,7 +91,7 @@ public class Persistence extends JDO_Test {
 
     /** */
     public void testGetPMFfromNamedPUWithOverrides() {
-        String name = "PUNamed_" + identitytype + "0";
+        String name = "PUNamed_" + IDENTITYTYPE + "0";
         Properties overrides = new Properties();
         overrides.setProperty(Constants.PROPERTY_RESTORE_VALUES, "true");
         pmf = JDOHelper.getPersistenceManagerFactory(overrides, name);
@@ -102,7 +102,7 @@ public class Persistence extends JDO_Test {
 
     /** */
     public void testGetPMFfromNamedPUWithWhiteSpace() {
-        String name = "PUNamed_" + identitytype + "0";
+        String name = "PUNamed_" + IDENTITYTYPE + "0";
         pmf = JDOHelper.getPersistenceManagerFactory(" \t" + name + " \n");
         assertEquals("Incorrect value for RestoreValues",
                 false, pmf.getRestoreValues());


### PR DESCRIPTION
Add a flag -Djdo.tck.skipJndi to skip the JNDI PMF tests that depend on any files with a restricted license.
I also renamed some of the static final fields in JDO_Test  to comply with the code conventions.