### PR TITLE
JDO-792: Add branch protection rules for 'master' branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,20 @@
+github:
+  description: "Apache JDO project"
+  homepage: https://db.apache.org/jdo
+  labels:
+    - db
+    - jdo
+    - nosql
+    - jpa
+    - jta
+    - api
+    - database
+    - orm
+    - apache
+    - java
+
+notifications:
+  commits:      jdo-commits@db.apache.org
+  issues:       jdo-dev@db.apache.org
+  pullrequests: jdo-dev@db.apache.org
+  jira_options: link label

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,6 +13,24 @@ github:
     - apache
     - java
 
+  enabled_merge_buttons:
+    # disable merge button:
+    merge:   false
+    # enable squash button:
+    squash:  true
+    # enable rebase button:
+    rebase:  true
+
+  protected_branches:
+    # rules for the 'master' branch
+    master:
+      # disallows pushing merge commits to the branch
+      required_linear_history: true
+
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+
 notifications:
   commits:      jdo-commits@db.apache.org
   issues:       jdo-dev@db.apache.org

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-jdo:
     name: Build JDO & Run TCK
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
#### Rename GitHub action jobs

Renames the GitHub action "Job" entries to make them distinguishable.
The "Job" entry is used to specify which actions to require before
merging. Therefore, giving them distinct names is important.

#### Add basic '.asf.yaml' configuration

Adds a basic '.asf.yaml' configuration matching the setup of the
db-jdo-site repository.

Updates the repository tags to include all tags present for the site
repository.

Explicitly sets the notification options. The settings match the current
default settings.

Updates the "About" section from "Apache db JDO" to "Apache JDO
project" to match the site repository.

#### JDO-792: Add branch protection rules

Adds the following branch protection rules for the 'master' branch:
- require a linear history (disallow merge commits)
- require the 'build-jdo' action to pass before merging a PR
- ~require PRs to be up-to-date before merging~

Disables the option "Create a merge commit" for merging a PR as merge
commits are not desired.