### PR TITLE
Update HowToReleaseJDO.md

### DIFF
--- a/HowToReleaseJDO.md
+++ b/HowToReleaseJDO.md
@@ -171,72 +171,68 @@ Detailed process steps
     lib/jdori count as local modifications. Be prepared to enter your
     key passcode when prompted. This happens multiple times.
 
-         mvn release:prepare -Papache-release -DautoVersionSubmodules=true -DdryRun=true -Dresume=false
+    The release plugin will will ask the following questions and expects an input:
+    What is the release version for "JDO Root POM"?
+    What is the SCM release tag or label for "JDO Root POM"?
+    What is the new development version for "JDO Root POM"?
+    The proposed defaults should be fine.
 
-         mvn deploy -Papache-release 
-            
-
+        mkdir tmp
+        cd tmp 
+        git clone https://github.com/apache/db-jdo.git
+        cd db-jdo
+        mvn release:prepare -Papache-release -DautoVersionSubmodules=true -DdryRun=true -Dresume=false
+        mvn deploy -Papache-release 
+  
     Check the artifacts at [the Maven release
     repository](https://repository.apache.org/content/repositories/snapshots/)
 
-13. Prepare and release the artifacts. There are interoperability issues
+14. Prepare and release the artifacts. There are interoperability issues
     with the maven release plugin and cygwin, so if on Windows, use a
     Windows command window for this step and the following one.
 
         mvn release:clean -Papache-release
         mvn release:prepare -Papache-release
-              
 
-    Note: If you're located in Europe then release:prepare may fail with
-    'Unable to tag SCM' and ' svn: No such revision X '. Wait 10 seconds
-    and run mvn release:prepare again.
-
-14. Stage the release for a vote.
+15. Stage the release for a vote.
 
         mvn release:perform -Papache-release
-            
 
-15. Go to [the Nexus
+16. Go to [the Nexus
     repository](https://repository.apache.org/index.html), login with
     your apache account, click on Staging Repositories in the menu on
     the left and close the staged repository. Press the refresh button
-    to see the new status 'closed'. See [11.4.1. Closing an Open
-    Repository](http://books.sonatype.com/nexus-book/reference/staging-repositories.html)
+    to see the new status 'closed'. See [Closing an Open Repository](https://help.sonatype.com/repomanager2/staging-releases/managing-staging-repositories#ManagingStagingRepositories-ClosinganOpenRepository)
     for details.
 
-16. Send an announcement to test the release to the
+17. Send an announcement (e.g. Subject: Please test staged JDO 3.2 release) 
+    to test the release to the
     jdo-dev@db.apache.org alias. If problems are found, fix and repeat.
 
-17. Send an announcement to vote on the release to the
+18. Send an announcement to vote on the release to the
     jdo-dev@db.apache.org alias. The message subject line contains
     \[VOTE\]. Forward the \[VOTE\] message to private@db.apache.org.
     Iterate until you get a successful vote. Mail the results of the
     vote to jdo-dev@db.apache.org, cc: general@db.apache.org, and
     include \[VOTE\] \[RESULTS\] in the subject line.
 
-18. After testing and voting is complete, follow the instructions at
-    [11.4.3. Releasing a Staging
-    Repository](http://books.sonatype.com/nexus-book/reference/staging-repositories.html)
+19. After testing and voting is complete, follow the instructions at
+    [Releasing a Staging Repository](https://help.sonatype.com/repomanager2/staging-releases/managing-staging-repositories#ManagingStagingRepositories-ReleasingaStagingRepository)
     to release the artifacts.
 
-19. Update the distribution repository at http://apache.org/dist/db/jdo/
-    by adding the new release directory to the svnpubsub directory.
-    Check out the repository at
+20. Update the distribution repository at https://apache.org/dist/db/jdo/
+    by adding the new release directory.
+    Check out the SVN repository at
     https://dist.apache.org/repos/dist/release/db/jdo and add the new
     release with all artifacts under the new directory. Make sure that
     the key used to sign the artifacts is included in the KEYS file.
     Committing the new directory will trigger an update to the mirrors.
 
-20. If the release is a bug fix release to a maintenance release, update
-    README.txt in the parent branch, adding the following line: "This
-    release has been deprecated. Please use version 2.x.y.", with a link
-    to the svn web interface for that version.
-
 21. After updating the site (below), announce the release to the Apache
     community via email to announce@apache.org This must be sent from an
-    @apache.org email address. \*\*\* Be aware that by sending to this
+    @apache.org email address. **Be aware that by sending to this
     address you will be bombarded with piles of emails from people with
-    "I'm out of the Office" as if you really cared \*\*\*
+    "I'm out of the Office" as if you really cared.**
 
 <span id="site"></span>
 
@@ -245,31 +241,15 @@ Site updates
 
 1.  Update the Apache JDO web site to point the downloads page to the
     release.
-    1.  In site/src/site/xdoc/releases create release-*N.n*.xml. Edit
-        the release numbers and the link to the release notes. You will
-        need to change the '&'s in the URL to "&amp;"
+    1.  In [dbo-jdo-site/src/main/asciidoc](https://github.com/apache/db-jdo-site/tree/master/src/main/asciidoc)
+        create release-*N.n*.adoc.
 
-    2.  In site/src/site/resources/releases create release-*N.n*.cgi.
-        The .cgi file contents are identical to the other .cgi files in
-        the release directory; only the file name differs.
+    2.  Edit db-jdo-site/src/main/asciidoc/downloads.adoc to link to the 
+        new release page .adoc document.
 
-    3.  Edit site/src/site/xdoc/downloads.xml to link to the new release
-        page .cgi document.
-
-    4.  Build and test as described in the site/HOWTO document. Note
-        that the cgi page will not be active until it is on the server,
-        so can't really be tested.
-
-    5.  Add the new files to the subversion repository.
-
-            svn add site/src/site/xdoc/releases/release-N.n.xml 
-            svn add site/docs/releases/release-N.n.html 
-            svn add site/src/site/resources/releases/release-N.n.cgi 
-            svn add site/docs/releases/release-N.n.cgi 
-                
-
-    6.  Set the svn properties svn:eol-style to native and
-        svn:executable to true for the .cgi files.
+    3.  Build and test as described in the [db-jdo-site/README.md](https://github.com/apache/db-jdo-site/blob/master/README.md) 
+        document. 
+        
 2.  Change the link to RunRules on the
     [TCK](http://db.apache.org/jdo/tck.html) page to link to the
     RunRules.html file of the latest release.

--- a/HowToReleaseJDO.md
+++ b/HowToReleaseJDO.md
@@ -52,7 +52,7 @@ releases. Each suffix release goes through the process documented here.
 The community decides whether to continue development on the main branch 
 while the release is in progress. In this case, a branch is created 
 first. If a new branch is needed, the release manager makes a new branch 
-from the master branch (for a major release) or from another branch (for 
+from the main branch (for a major release) or from another branch (for 
 a minor release). If a new branch is not needed, the release will be 
 created from the main branch and a release branch will only be created 
 later for a maintenance release.
@@ -100,9 +100,9 @@ Detailed process steps
 
         mvn clean apache-rat:check
 
-2.  If necessary, create a branch from the master branch and increment the 
+2.  If necessary, create a branch from the main branch and increment the 
     spec or major number. For example, create a "3.1" branch from the 
-    master branch.
+    main branch.
 
         git checkout -b 3.2
         git push -u 3.2
@@ -119,7 +119,7 @@ Detailed process steps
 4.  If needed, update the dependency to the RI, DataNucleus, in the tck
     pom.xml.
 
-5.  If needed, apply patches from the master branch to the release branch.
+5.  If needed, apply patches from the main branch to the release branch.
 
 6.  Update version numbers where necessary in projects to be released,
     if these changes haven't been made previously. Check the following
@@ -132,7 +132,7 @@ Detailed process steps
     Update version number
 
 7.  Check the scm settings in the pom.xml files in the new branch and
-    make sure they refer to the new branch (instead of the master branch).
+    make sure they refer to the new branch (instead of the main branch).
 
 8.  Follow the instructions at [Publishing Maven
     Artifacts](http://www.apache.org/dev/publishing-maven-artifacts.html)

--- a/HowToReleaseJDO.md
+++ b/HowToReleaseJDO.md
@@ -252,7 +252,7 @@ Site updates
         
 2.  Change the link to RunRules on the
     [TCK](http://db.apache.org/jdo/tck.html) page to link to the
-    RunRules.html file of the latest release.
+    RunRules.md file of the latest release.
 3.  Update the news list on the site home page to announce the new
     release.
 4.  Update the specification page to link to the new specification pdf
@@ -260,15 +260,15 @@ Site updates
     documentation page of the JCP web site. If the release has not been
     approved by the JCP, link to the .pdf in the JDO source repository.
 5.  Add the javadoc for the release to the site.
-    1.  Make a new directory under site/docs for the release, e.g.
-        api2.1. We'll call it *docsdir*.
+    1.  Make a new directory under [db-jdo-site/src/main/resources/javadoc](https://github.com/apache/db-jdo-site/tree/master/src/main/resources/javadoc) 
+        for the release, e.g. api2.1. We'll call it *docsdir*.
     2.  Download the javadoc artifact from the repository and copy it to
         *docsdir*.
     3.  Unzip it in *docsdir*.
-    4.  Do svn add on *docsdir*.
-    5.  Edit xdocs/javadoc.xml and add links to the new javadoc.
-6.  Build and test. Follow the instructions in site/HOWTO to push the
-    site changes to the Apache web site.
+    4.  Do `git add` on *docsdir*.
+    5.  Edit  db-jdo-site/src/main/asciidoc/javadoc.adoc and add links to the new javadoc.
+6.  Build and test. Follow the instructions in [db-jdo-site/README.md](https://github.com/apache/db-jdo-site/blob/master/README.md)
+    to push the site changes to the Apache web site.
 
 <span id="postrelease"></span>
 
@@ -282,8 +282,7 @@ be modified because a test challenge is found to be valid.
     number. For example, create a branch named 2.1.1, from the 2.1
     branch.
 2.  Merge bug fixes or other modifications into the new branch.
-3.  In the new branch, modify trunk/README.txt to include a section on
-    bug fixes since the 2.1 release, and to suggest checking out the
+3.  In the new branch, modify README.md to include a section on
+    bug fixes since the previous release, and to suggest checking out the
     source from a bug-fix branch to get the fixes listed.
-4.  Link to this README in the web interface to svn from the .cgi
-    download page and from http://db.apache.org/jdo/tck.html.
+4.  Link to this README in the download page of the release.


### PR DESCRIPTION
This PR includes updates to the `ReleaseHowTo.md`:
* updates as discussed in previous telecons
* updates to the site-release and post-release instructions.

Comments are welcome.

Note that the document uses *master* instead of *main* (to replace *trunk*). I did this due to the recent discussion. I am happy to change this to the previously agreed *main* (which is more generic). Please let me know.