### PR TITLE
JDO-807: Update schema descriptor of JDO Metadata file 

### DIFF
--- a/api/src/test/java/javax/jdo/util/XMLTestUtil.java
+++ b/api/src/test/java/javax/jdo/util/XMLTestUtil.java
@@ -36,10 +36,16 @@ import java.util.Map;
 import java.util.StringTokenizer;
 
 import javax.jdo.JDOFatalException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
-import javax.xml.parsers.*;
 import org.w3c.dom.Document;
-import org.xml.sax.*;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * Tests schema files.
@@ -76,15 +82,15 @@ public class XMLTestUtil {
 
     /** jdo xsd file */
     protected static final File JDO_XSD_FILE = 
-        new File(BASEDIR + "/target/classes/javax/jdo/jdo_2_2.xsd");
+        new File(BASEDIR + "/target/classes/javax/jdo/jdo_3_2.xsd");
 
     /** orm xsd file */
     protected static final File ORM_XSD_FILE = 
-        new File(BASEDIR + "/target/classes/javax/jdo/orm_2_2.xsd");
+        new File(BASEDIR + "/target/classes/javax/jdo/orm_3_2.xsd");
 
     /** jdoquery xsd file */
     protected static final File JDOQUERY_XSD_FILE = 
-        new File(BASEDIR + "/target/classes/javax/jdo/jdoquery_2_2.xsd");
+        new File(BASEDIR + "/target/classes/javax/jdo/jdoquery_3_2.xsd");
 
     /** Entity resolver */
     protected static final EntityResolver resolver = new JDOEntityResolver();
@@ -107,7 +113,7 @@ public class XMLTestUtil {
     protected static final String NL = System.getProperty("line.separator");
 
     /** XSD builder for jdo namespace. */
-    private final DocumentBuilder jdoXsdBuilder = 
+    private final DocumentBuilder jdoXsdBuilder =
         createBuilder(JDO_XSD_NS + " " + JDO_XSD_FILE.toURI().toString());
     
     /** XSD builder for orm namespace. */
@@ -357,29 +363,29 @@ public class XMLTestUtil {
         implements EntityResolver {
 
         private static final String RECOGNIZED_JDO_PUBLIC_ID = 
-            "-//Sun Microsystems, Inc.//DTD Java Data Objects Metadata 2.2//EN";
+            "-//Sun Microsystems, Inc.//DTD Java Data Objects Metadata 3.2//EN";
         private static final String RECOGNIZED_JDO_SYSTEM_ID = 
-            "file:/javax/jdo/jdo_2_2.dtd";
+            "file:/javax/jdo/jdo_3_2.dtd";
         private static final String RECOGNIZED_JDO_SYSTEM_ID2 = 
-            "http://xmlns.jcp.org/dtd/jdo_2_2.dtd";
+            "http://xmlns.jcp.org/dtd/jdo_3_2.dtd";
         private static final String RECOGNIZED_ORM_PUBLIC_ID = 
-            "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN";
+            "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN";
         private static final String RECOGNIZED_ORM_SYSTEM_ID = 
-            "file:/javax/jdo/orm_2_2.dtd";
+            "file:/javax/jdo/orm_3_2.dtd";
         private static final String RECOGNIZED_ORM_SYSTEM_ID2 = 
-            "http://xmlns.jcp.org/dtd/orm_2_2.dtd";
+            "http://xmlns.jcp.org/dtd/orm_3_2.dtd";
         private static final String RECOGNIZED_JDOQUERY_PUBLIC_ID = 
-            "-//Sun Microsystems, Inc.//DTD Java Data Objects Query Metadata 2.2//EN";
+            "-//Sun Microsystems, Inc.//DTD Java Data Objects Query Metadata 3.2//EN";
         private static final String RECOGNIZED_JDOQUERY_SYSTEM_ID = 
-            "file:/javax/jdo/jdoquery_2_2.dtd";
+            "file:/javax/jdo/jdoquery_3_2.dtd";
         private static final String RECOGNIZED_JDOQUERY_SYSTEM_ID2 = 
-            "http://xmlns.jcp.org/dtd/jdoquery_2_2.dtd";
+            "http://xmlns.jcp.org/dtd/jdoquery_3_2.dtd";
         private static final String JDO_DTD_FILENAME = 
-            "javax/jdo/jdo_2_2.dtd";
+            "javax/jdo/jdo_3_2.dtd";
         private static final String ORM_DTD_FILENAME = 
-            "javax/jdo/orm_2_2.dtd";
+            "javax/jdo/orm_3_2.dtd";
         private static final String JDOQUERY_DTD_FILENAME = 
-            "javax/jdo/jdoquery_2_2.dtd";
+            "javax/jdo/jdoquery_3_2.dtd";
 
         static Map<String,String> publicIds = new HashMap<String,String>();
         static Map<String,String> systemIds = new HashMap<String,String>();

--- a/api/src/test/resources/Negative0-dtd.jdo
+++ b/api/src/test/resources/Negative0-dtd.jdo
@@ -17,7 +17,7 @@
 -->
 <!-- Negative test: empty jdo element --> 
 <!DOCTYPE jdo PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Metadata 2.2//EN"
-        "http://xmlns.jcp.org/dtd/jdo_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Metadata 3.2//EN"
+        "http://xmlns.jcp.org/dtd/jdo_3_2.dtd">
 <jdo>
 </jdo>

--- a/api/src/test/resources/Negative0-dtd.jdoquery
+++ b/api/src/test/resources/Negative0-dtd.jdoquery
@@ -17,7 +17,7 @@
 -->
 <!-- Negative test: empty jdoquery element --> 
 <!DOCTYPE jdo PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Query Metadata 2.2//EN"
-        "http://xmlns.jcp.org/dtd/jdoquery_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Query Metadata 3.2//EN"
+        "http://xmlns.jcp.org/dtd/jdoquery_3_2.dtd">
 <jdoquery>
 </jdoquery>

--- a/api/src/test/resources/Negative0-dtd.orm
+++ b/api/src/test/resources/Negative0-dtd.orm
@@ -17,7 +17,7 @@
 -->
 <!-- Negative test: empty orm element --> 
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/dtd/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/dtd/orm_3_2.dtd">
 <orm>
 </orm>

--- a/api/src/test/resources/Negative0-xsd.jdo
+++ b/api/src/test/resources/Negative0-xsd.jdo
@@ -18,6 +18,6 @@
 <!-- Negative test: empty jdo element --> 
 <jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo 
-                         http://xmlns.jcp.org/xml/ns/jdo/jdo_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 </jdo>

--- a/api/src/test/resources/Negative0-xsd.jdoquery
+++ b/api/src/test/resources/Negative0-xsd.jdoquery
@@ -18,7 +18,7 @@
 <!-- Negative test: empty jdoquery element --> 
 <jdoquery xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdoquery"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdoquery 
-                         http://xmlns.jcp.org/xml/ns/jdo/jdoquery_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdoquery
+     http://xmlns.jcp.org/xml/ns/jdo/jdoquery_3_2.xsd">
 
 </jdoquery>

--- a/api/src/test/resources/Negative0-xsd.orm
+++ b/api/src/test/resources/Negative0-xsd.orm
@@ -18,6 +18,6 @@
 <!-- Negative test: empty orm element --> 
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 </orm>

--- a/api/src/test/resources/Positive0-dtd.jdo
+++ b/api/src/test/resources/Positive0-dtd.jdo
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE jdo PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Metadata 2.2//EN"
-        "http://xmlns.jcp.org/dtd/jdo_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Metadata 3.2//EN"
+        "http://xmlns.jcp.org/dtd/jdo_3_2.dtd">
 <jdo>
     <package name="simple">
         <class name="TestClass"/>

--- a/api/src/test/resources/Positive0-dtd.jdoquery
+++ b/api/src/test/resources/Positive0-dtd.jdoquery
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE jdoquery  PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Query Metadata 2.2//EN"
-        "http://xmlns.jcp.org/dtd/jdoquery_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Query Metadata 3.2//EN"
+        "http://xmlns.jcp.org/dtd/jdoquery_3_2.dtd">
 <jdoquery>
     <package name="simple">
         <class name="TestClass">

--- a/api/src/test/resources/Positive0-dtd.orm
+++ b/api/src/test/resources/Positive0-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
     <package name="simple">
         <class name="TestClass"/>

--- a/api/src/test/resources/Positive0-xsd.jdo
+++ b/api/src/test/resources/Positive0-xsd.jdo
@@ -17,8 +17,8 @@
 -->
 <jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo 
-                         http://xmlns.jcp.org/xml/ns/jdo/jdo_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="simple">
         <class name="TestClass"/>
     </package>

--- a/api/src/test/resources/Positive0-xsd.jdoquery
+++ b/api/src/test/resources/Positive0-xsd.jdoquery
@@ -17,8 +17,8 @@
 -->
 <jdoquery xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdoquery"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdoquery 
-                         http://xmlns.jcp.org/xml/ns/jdo/jdoquery_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdoquery
+     http://xmlns.jcp.org/xml/ns/jdo/jdoquery_3_2.xsd">
     <package name="simple">
         <class name="TestClass">
             <query

--- a/api/src/test/resources/Positive0-xsd.orm
+++ b/api/src/test/resources/Positive0-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="simple">
         <class name="TestClass"/>
     </package>

--- a/api/src/test/resources/Positive1-dtd.jdo
+++ b/api/src/test/resources/Positive1-dtd.jdo
@@ -15,8 +15,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!DOCTYPE jdo PUBLIC "-//Sun Microsystems, Inc.//DTD Java Data Objects Metadata 2.2//EN" 
-  "http://xmlns.jcp.org/dtd/jdo_2_2.dtd">
+<!DOCTYPE jdo PUBLIC "-//Sun Microsystems, Inc.//DTD Java Data Objects Metadata 3.2//EN"
+  "http://xmlns.jcp.org/dtd/jdo_3_2.dtd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/api/src/test/resources/Positive1-dtd.orm
+++ b/api/src/test/resources/Positive1-dtd.orm
@@ -15,7 +15,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!DOCTYPE orm PUBLIC "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN" "http://xmlns.jcp.org/dtd/orm_2_2.dtd">
+<!DOCTYPE orm PUBLIC "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+  "http://xmlns.jcp.org/dtd/orm_2_2.dtd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/api/src/test/resources/Positive1-xsd.jdo
+++ b/api/src/test/resources/Positive1-xsd.jdo
@@ -21,8 +21,8 @@ has application identity.
 -->
 <jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo 
-                         http://xmlns.jcp.org/xml/ns/jdo/jdo_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.company">
 
         <class name="Address" embedded-only="true" requires-extent="false"/>

--- a/api/src/test/resources/Positive1-xsd.orm
+++ b/api/src/test/resources/Positive1-xsd.orm
@@ -21,8 +21,8 @@ has application identity.
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.company">
 
         <class name="Address"/>

--- a/api/src/test/resources/Positive15.1-dtd.orm
+++ b/api/src/test/resources/Positive15.1-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
     <package name="com.xyz">
         <class name="Address" table="ADDR">

--- a/api/src/test/resources/Positive15.1-xsd.orm
+++ b/api/src/test/resources/Positive15.1-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="com.xyz">
         <class name="Address" table="ADDR">
             <field name="street" column="STREET"/>

--- a/api/src/test/resources/Positive15.2.1-dtd.orm
+++ b/api/src/test/resources/Positive15.2.1-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Address" table="ADDR">

--- a/api/src/test/resources/Positive15.2.1-xsd.orm
+++ b/api/src/test/resources/Positive15.2.1-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Address" table="ADDR">
 			<!-- shared join condition used by fields in DELIV -->

--- a/api/src/test/resources/Positive15.2.2-dtd.orm
+++ b/api/src/test/resources/Positive15.2.2-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Address" table="ADDR">

--- a/api/src/test/resources/Positive15.2.2-xsd.orm
+++ b/api/src/test/resources/Positive15.2.2-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Address" table="ADDR">
 			<field name="street" column="STREET"/>

--- a/api/src/test/resources/Positive15.3.1-dtd.orm
+++ b/api/src/test/resources/Positive15.3.1-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.3.1-xsd.orm
+++ b/api/src/test/resources/Positive15.3.1-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">
 			<field name="ssn" column="SSN"/>

--- a/api/src/test/resources/Positive15.3.2-dtd.orm
+++ b/api/src/test/resources/Positive15.3.2-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Department" table="DEP">

--- a/api/src/test/resources/Positive15.3.2-xsd.orm
+++ b/api/src/test/resources/Positive15.3.2-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Department" table="DEP">
  			<field name="name" column="NAME"/>

--- a/api/src/test/resources/Positive15.3.3-dtd.orm
+++ b/api/src/test/resources/Positive15.3.3-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.3.3-xsd.orm
+++ b/api/src/test/resources/Positive15.3.3-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">
 			<field name="ssn" column="SSN"/>

--- a/api/src/test/resources/Positive15.3.4-dtd.orm
+++ b/api/src/test/resources/Positive15.3.4-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.3.4-xsd.orm
+++ b/api/src/test/resources/Positive15.3.4-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">
 			<field name="ssn" column="SSN"/>

--- a/api/src/test/resources/Positive15.3.5-dtd.orm
+++ b/api/src/test/resources/Positive15.3.5-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.3.5-xsd.orm
+++ b/api/src/test/resources/Positive15.3.5-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">
 			<field name="ssn" column="SSN"/>

--- a/api/src/test/resources/Positive15.3.6-dtd.orm
+++ b/api/src/test/resources/Positive15.3.6-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.3.6-xsd.orm
+++ b/api/src/test/resources/Positive15.3.6-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
         <package name="com.xyz">
                 <class name="Employee" table="EMP">
                         <field name="ssn" column="SSN"/>

--- a/api/src/test/resources/Positive15.4-dtd.orm
+++ b/api/src/test/resources/Positive15.4-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.4-xsd.orm
+++ b/api/src/test/resources/Positive15.4-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">
 			<field name="ssn" column="SSN"/>

--- a/api/src/test/resources/Positive15.5-dtd.orm
+++ b/api/src/test/resources/Positive15.5-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.5-xsd.orm
+++ b/api/src/test/resources/Positive15.5-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">
 			<field name="ssn" column="SSN"/>

--- a/api/src/test/resources/Positive15.6-dtd.orm
+++ b/api/src/test/resources/Positive15.6-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Address" table="ADDR">

--- a/api/src/test/resources/Positive15.6-xsd.orm
+++ b/api/src/test/resources/Positive15.6-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Address" table="ADDR">
 			<index name="ADDR_CITYSTATE_IDX">

--- a/api/src/test/resources/Positive15.8.1-dtd.orm
+++ b/api/src/test/resources/Positive15.8.1-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.8.1-xsd.orm
+++ b/api/src/test/resources/Positive15.8.1-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">
 			<inheritance strategy="new-table">

--- a/api/src/test/resources/Positive15.8.2-dtd.orm
+++ b/api/src/test/resources/Positive15.8.2-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">

--- a/api/src/test/resources/Positive15.8.2-xsd.orm
+++ b/api/src/test/resources/Positive15.8.2-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee" table="EMP">
 			<inheritance strategy="new-table">

--- a/api/src/test/resources/Positive15.8.3-dtd.orm
+++ b/api/src/test/resources/Positive15.8.3-dtd.orm
@@ -16,8 +16,8 @@
   limitations under the License.
 -->
 <!DOCTYPE orm PUBLIC 
-    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 2.2//EN"
-        "http://xmlns.jcp.org/schema/orm_2_2.dtd">
+    "-//Sun Microsystems, Inc.//DTD Java Data Objects Mapping Metadata 3.2//EN"
+        "http://xmlns.jcp.org/schema/orm_3_2.dtd">
 <orm>
 	<package name="com.xyz">
 		<class name="Employee">

--- a/api/src/test/resources/Positive15.8.3-xsd.orm
+++ b/api/src/test/resources/Positive15.8.3-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 	<package name="com.xyz">
 		<class name="Employee">
 			<inheritance strategy="subclass-table"/>

--- a/api/src/test/resources/Positive99-dtd.jdo
+++ b/api/src/test/resources/Positive99-dtd.jdo
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!DOCTYPE jdo SYSTEM "file:/javax/jdo/jdo_2_2.dtd">
+<!DOCTYPE jdo SYSTEM "file:/javax/jdo/jdo_3_2.dtd">
 <jdo>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>

--- a/api/src/test/resources/Positive99-dtd.jdoquery
+++ b/api/src/test/resources/Positive99-dtd.jdoquery
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!DOCTYPE jdoquery SYSTEM "file:/javax/jdo/jdoquery_2_2.dtd">
+<!DOCTYPE jdoquery SYSTEM "file:/javax/jdo/jdoquery_3_2.dtd">
 <jdoquery>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>

--- a/api/src/test/resources/Positive99-dtd.orm
+++ b/api/src/test/resources/Positive99-dtd.orm
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!DOCTYPE orm SYSTEM "file:/javax/jdo/orm_2_2.dtd">
+<!DOCTYPE orm SYSTEM "file:/javax/jdo/orm_3_2.dtd">
 <orm>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>

--- a/api/src/test/resources/Positive99-xsd.jdo
+++ b/api/src/test/resources/Positive99-xsd.jdo
@@ -17,8 +17,8 @@
 -->
 <jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo 
-                         http://xmlns.jcp.org/xml/ns/jdo/jdo_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <package 

--- a/api/src/test/resources/Positive99-xsd.jdoquery
+++ b/api/src/test/resources/Positive99-xsd.jdoquery
@@ -17,8 +17,8 @@
 -->
 <jdoquery xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdoquery"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdoquery 
-                         http://xmlns.jcp.org/xml/ns/jdo/jdoquery_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdoquery
+     http://xmlns.jcp.org/xml/ns/jdo/jdoquery_3_2.xsd">
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <package 

--- a/api/src/test/resources/Positive99-xsd.orm
+++ b/api/src/test/resources/Positive99-xsd.orm
@@ -17,8 +17,8 @@
 -->
 <orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm 
-                         http://xmlns.jcp.org/xml/ns/jdo/orm_2_2.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <extension vendor-name="SUNW" key="KEY" value="VALUE"/>
   <package 

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/api/instancecallbacks/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/api/instancecallbacks/package.jdo
@@ -18,10 +18,10 @@
 <!--
 This file contains the persistence information for persistence-capable classes 
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.api.instancecallbacks">
         <class name="InstanceLifecycleListenerAttach$PC" detachable="true">
             <field name="id" primary-key="true"/>

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/package.jdo
@@ -19,10 +19,10 @@
 This file contains the schema information for persistence-aware classes 
 and SimpleClass, which is needed for several fieldtypes tests.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.models.inheritance">
         <class name="FieldWithSameNameInSuperclass" persistence-modifier="persistence-aware"/>
         <class name="NonPersistentFieldsAreNonPersistentInSubclasses" persistence-modifier="persistence-aware"/>

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/building/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/building/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-    http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 
     <package name="org.apache.jdo.tck.pc.building">
 

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/company/Person.jdoquery
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/company/Person.jdoquery
@@ -18,10 +18,10 @@
 <!--
 This file contains a named query for class Person.
 -->
-<jdoquery xmlns="http://java.sun.com/xml/ns/jdo/jdoquery"
+<jdoquery xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdoquery"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdoquery 
-	http://java.sun.com/xml/ns/jdo/jdoquery_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdoquery
+     http://xmlns.jcp.org/xml/ns/jdo/jdoquery_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.company">
 
         <class name="Person">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/company/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/company/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/companyListWithoutJoin/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/companyListWithoutJoin/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/companyMapWithoutJoin/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/companyMapWithoutJoin/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/converter/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/converter/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.converter">
 
     <class name="PCRect"

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/AllTypes.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/AllTypes.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="AllTypes" identity-type="application"
             objectid-class="org.apache.jdo.tck.pc.fieldtypes.AllTypes$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="ArrayCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.ArrayCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayListCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayListCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="ArrayListCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.ArrayListCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/CollectionCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/CollectionCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="CollectionCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.CollectionCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigDecimal.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigDecimal.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfBigDecimal" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfBigDecimal$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigInteger.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigInteger.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfBigInteger" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfBigInteger$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBoolean.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBoolean.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfBoolean" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfBoolean$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfByte.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfByte.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfByte" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfByte$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfCharacter.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfCharacter.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfCharacter" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfCharacter$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDate.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDate.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfDate" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfDate$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDouble.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDouble.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfDouble" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfDouble$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfFloat.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfFloat.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfFloat" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfFloat$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfInteger.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfInteger.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfInteger" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfInteger$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLocale.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLocale.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfLocale" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfLocale$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLong.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLong.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfLong" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfLong$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfObject.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfObject.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfObject" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfObject$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveboolean.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveboolean.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitiveboolean" identity-type="application" 
   objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfPrimitiveboolean$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivebyte.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivebyte.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivebyte" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfPrimitivebyte$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivechar.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivechar.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivechar" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfPrimitivechar$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivedouble.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivedouble.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivedouble" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfPrimitivedouble$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivefloat.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivefloat.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivefloat" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfPrimitivefloat$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveint.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveint.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitiveint" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfPrimitiveint$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivelong.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivelong.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivelong" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfPrimitivelong$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveshort.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveshort.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitiveshort" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfPrimitiveshort$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfShort.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfShort.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfShort" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfShort$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleClass.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleClass.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfSimpleClass" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfSimpleClass$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfSimpleEnum" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfSimpleEnum$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleInterface.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleInterface.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfSimpleInterface" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfSimpleInterface$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfString.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfString.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfString" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.FieldsOfString$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringKeyCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringKeyCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashMapStringKeyCollections" identity-type="application"
   objectid-class="org.apache.jdo.tck.pc.fieldtypes.HashMapStringKeyCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringValueCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringValueCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashMapStringValueCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.HashMapStringValueCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashSetCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashSetCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashSetCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.HashSetCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringKeyCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringKeyCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashtableStringKeyCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.HashtableStringKeyCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringValueCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringValueCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashtableStringValueCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.HashtableStringValueCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/LinkedListCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/LinkedListCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="LinkedListCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.LinkedListCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ListCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ListCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="ListCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.ListCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringKeyCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringKeyCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="MapStringKeyCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.MapStringKeyCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringValueCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringValueCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="MapStringValueCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.MapStringValueCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/SetCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/SetCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="SetCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.SetCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringKeyCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringKeyCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="TreeMapStringKeyCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.TreeMapStringKeyCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringValueCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringValueCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="TreeMapStringValueCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.TreeMapStringValueCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeSetCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeSetCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="TreeSetCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.TreeSetCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/VectorCollections.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/VectorCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="VectorCollections" identity-type="application"
     objectid-class="org.apache.jdo.tck.pc.fieldtypes.VectorCollections$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/inheritance/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/inheritance/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.inheritance">
         <class
             name="AllPersist"

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/instancecallbacks/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/instancecallbacks/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.instancecallbacks">
         <class name="InstanceCallbackNonPersistFdsClass" 
             identity-type="application"

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.lifecycle">
 
     <class name="StateTransitionObj" 

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/mylib/PCClass.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/mylib/PCClass.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
     <class name="PCClass" 
            identity-type="application" objectid-class="org.apache.jdo.tck.pc.mylib.PCClass$Oid">

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/mylib/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/mylib/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
 
     <class name="PCPoint"

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/AAddress.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/AAddress.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/AAddress_bad.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/AAddress_bad.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/Address.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/Address.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/Address_bad.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/Address_bad.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/IAddress.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/IAddress.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/IAddress_bad.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/newInstance/IAddress_bad.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/order/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/order/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/query/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/query/package.jdo
@@ -16,10 +16,10 @@
   limitations under the License.
 -->
 
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.query">
 
     <class name="JDOQLKeywordsAsFieldNames"

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/shoppingcart/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/shoppingcart/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.shoppingcart">
 
         <class

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/singlefieldidentity/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/singlefieldidentity/package.jdo
@@ -16,10 +16,10 @@
   limitations under the License.
 -->
 
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.singlefieldidentity">
 
     <class name="PCPointSingleFieldPrimitivebyte"

--- a/tck/src/main/resources/jdo/applicationidentity/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/package.jdo
@@ -19,10 +19,10 @@
 This file contains a named query which may be found 
 calling pm.newNamedQuery(null, "packageJDOInDefaultPackage").
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <query name="packageJDOInDefaultPackage">
         SELECT FROM org.apache.jdo.tck.pc.company.Person
     </query>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/api/instancecallbacks/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/api/instancecallbacks/package.jdo
@@ -18,10 +18,10 @@
 <!--
 This file contains the persistence information for persistence-capable classes 
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.api.instancecallbacks">
         <class name="InstanceLifecycleListenerAttach$PC" 
                 identity-type="datastore" detachable="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/package.jdo
@@ -19,10 +19,10 @@
 This file contains the schema information for persistence-aware classes 
 and SimpleClass, which is needed for several fieldtypes tests.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.models.inheritance">
         <class name="FieldWithSameNameInSuperclass" persistence-modifier="persistence-aware"/>
         <class name="NonPersistentFieldsAreNonPersistentInSubclasses" persistence-modifier="persistence-aware"/>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/building/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/building/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-    http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 
     <package name="org.apache.jdo.tck.pc.building">
 

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/company/Person.jdoquery
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/company/Person.jdoquery
@@ -18,10 +18,10 @@
 <!--
 This file contains a named query for class Person.
 -->
-<jdoquery xmlns="http://java.sun.com/xml/ns/jdo/jdoquery"
+<jdoquery xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdoquery"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdoquery 
-	http://java.sun.com/xml/ns/jdo/jdoquery_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdoquery
+     http://xmlns.jcp.org/xml/ns/jdo/jdoquery_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.company">
 
         <class name="Person">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/company/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/company/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/companyListWithoutJoin/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/companyListWithoutJoin/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/companyMapWithoutJoin/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/companyMapWithoutJoin/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/converter/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/converter/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.converter">
 
     <class name="PCRect" identity-type="datastore">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/AllTypes.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/AllTypes.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="AllTypes">
         </class>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="ArrayCollections" identity-type="datastore">
 <field name="ArrayOfObject0" persistence-modifier="persistent">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayListCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayListCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="ArrayListCollections" identity-type="datastore">
 <field name="ArrayListOfObject0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/CollectionCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/CollectionCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="CollectionCollections" identity-type="datastore">
 <field name="CollectionOfObject0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigDecimal.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigDecimal.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfBigDecimal" identity-type="datastore">
 <field name="BigDecimal1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigInteger.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigInteger.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfBigInteger" identity-type="datastore">
 <field name="BigInteger1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBoolean.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBoolean.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfBoolean" identity-type="datastore">
 <field name="Boolean1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfByte.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfByte.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfByte" identity-type="datastore">
 <field name="Byte1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfCharacter.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfCharacter.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfCharacter" identity-type="datastore">
 <field name="Character1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDate.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDate.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfDate" identity-type="datastore">
 <field name="Date1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDouble.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDouble.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfDouble" identity-type="datastore">
 <field name="Double1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfFloat.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfFloat.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfFloat" identity-type="datastore">
 <field name="Float1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfInteger.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfInteger.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfInteger" identity-type="datastore">
 <field name="identifier"  persistence-modifier="none"/>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLocale.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLocale.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfLocale" identity-type="datastore">
 <field name="Locale1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLong.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLong.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfLong" identity-type="datastore">
 <field name="Long1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfObject.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfObject.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfObject" identity-type="datastore">
 <field name="Object1"  serialized="true" persistence-modifier="persistent"

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveboolean.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveboolean.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitiveboolean" identity-type="datastore">
 <field name="boolean1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivebyte.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivebyte.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivebyte" identity-type="datastore">
 <field name="byte1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivechar.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivechar.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivechar" identity-type="datastore">
 <field name="identifier"  persistence-modifier="none"/>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivedouble.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivedouble.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivedouble" identity-type="datastore">
 <field name="double1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivefloat.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivefloat.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivefloat" identity-type="datastore">
 <field name="float1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveint.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveint.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitiveint" identity-type="datastore">
 <field name="int1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivelong.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivelong.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitivelong" identity-type="datastore">
 <field name="long1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveshort.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveshort.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfPrimitiveshort" identity-type="datastore">
 <field name="short1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfShort.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfShort.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfShort" identity-type="datastore">
 <field name="Short1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleClass.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleClass.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfSimpleClass" identity-type="datastore">
 <field name="SimpleClass1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfSimpleEnum" identity-type="datastore">
 <field name="identifier"  persistence-modifier="none"/>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleInterface.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleInterface.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfSimpleInterface" identity-type="datastore">
 <field name="SimpleInterface1"  serialized="true" persistence-modifier="persistent">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfString.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfString.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="FieldsOfString" identity-type="datastore">
 <field name="String1"  embedded="true">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringKeyCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringKeyCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashMapStringKeyCollections" identity-type="datastore">
 <field name="HashMapOfString_Object0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringValueCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringValueCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashMapStringValueCollections" identity-type="datastore">
 <field name="HashMapOfObject_String0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashSetCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashSetCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashSetCollections" identity-type="datastore">
 <field name="HashSetOfObject0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringKeyCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringKeyCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashtableStringKeyCollections" identity-type="datastore">
 <field name="HashtableOfString_Object0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringValueCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringValueCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="HashtableStringValueCollections" identity-type="datastore">
 <field name="HashtableOfObject_String0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/LinkedListCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/LinkedListCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="LinkedListCollections" identity-type="datastore">
 <field name="LinkedListOfObject0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ListCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ListCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="ListCollections" identity-type="datastore">
 <field name="ListOfObject0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringKeyCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringKeyCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="MapStringKeyCollections" identity-type="datastore">
 <field name="MapOfString_Object0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringValueCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringValueCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="MapStringValueCollections" identity-type="datastore">
 <field name="MapOfObject_String0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/SetCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/SetCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="SetCollections" identity-type="datastore">
 <field name="SetOfObject0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringKeyCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringKeyCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="TreeMapStringKeyCollections" identity-type="datastore">
 <field name="TreeMapOfString_Object0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringValueCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringValueCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="TreeMapStringValueCollections" identity-type="datastore">
 <field name="TreeMapOfObject_String0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeSetCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeSetCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="TreeSetCollections" identity-type="datastore">
 <field name="TreeSetOfObject0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/VectorCollections.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/VectorCollections.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <package name="org.apache.jdo.tck.pc.fieldtypes">
 <class name="VectorCollections" identity-type="datastore">
 <field name="VectorOfObject0" >

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/inheritance/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/inheritance/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.inheritance">
         <class 
             name="AllPersist" 

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/instancecallbacks/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/instancecallbacks/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.instancecallbacks">
         <class name="InstanceCallbackNonPersistFdsClass" 
             identity-type="datastore">

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.lifecycle">
     <class name="StateTransitionObj" identity-type="datastore" detachable="true"/>
   </package>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/mylib/PCClass.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/mylib/PCClass.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
     <class name="PCClass" identity-type="datastore">
       <field name="transientNumber1" persistence-modifier="none"/>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/mylib/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/mylib/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
 
     <class name="PCPoint" identity-type="datastore"/>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/AAddress.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/AAddress.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/AAddress_bad.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/AAddress_bad.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/Address.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/Address.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/Address_bad.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/Address_bad.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/IAddress.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/IAddress.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/IAddress_bad.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/newInstance/IAddress_bad.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/order/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/order/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
 <!--
 This file is not used!! It exists here to satisfy build constraints.
 -->

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/query/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/query/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.query">
     <class name="JDOQLKeywordsAsFieldNames" identity-type="datastore"/>
 

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/shoppingcart/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/shoppingcart/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.shoppingcart">
 
         <class

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/singlefieldidentity/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/singlefieldidentity/package.jdo
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.singlefieldidentity">
     <class name="PCPointSingleFieldPrimitivebyte" persistence-modifier="non-persistent"/>
     <class name="PCPointSingleFieldByte" persistence-modifier="non-persistent"/>

--- a/tck/src/main/resources/jdo/datastoreidentity/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/package.jdo
@@ -19,10 +19,10 @@
 This file contains a named query which may be found 
 calling pm.newNamedQuery(null, "packageJDOInDefaultPackage").
 -->
-<jdo xmlns="http://java.sun.com/xml/ns/jdo/jdo"
+<jdo xmlns="http://xmlns.jcp.org/xml/ns/jdo/jdo"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/jdo 
-	http://java.sun.com/xml/ns/jdo/jdo_3_0.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/jdo
+     http://xmlns.jcp.org/xml/ns/jdo/jdo_3_2.xsd">
     <query name="packageJDOInDefaultPackage">
         SELECT FROM org.apache.jdo.tck.pc.company.Person
     </query>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/api/instancecallbacks/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/api/instancecallbacks/package-standard.orm
@@ -19,10 +19,10 @@
 This file contains the schema information when an implementation
 has application identity.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.api.instancecallbacks">
 
         <class name="InstanceLifecycleListenerAttach$PC" 

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/building/package-standard12.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/building/package-standard12.orm
@@ -18,10 +18,10 @@
 <!--
 This file contains the schema information when an implementation has application-id.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.building">
         <class name="Kitchen" table="KITCHEN">
             <field name="id" column="KITCHEN_ID"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard1.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard1.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard2.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard2.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard3.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard3.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard4.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/company/package-standard4.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/companyAnnotatedFC/package-standard11.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/companyAnnotatedFC/package-standard11.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/companyListWithoutJoin/package-standard10.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/companyListWithoutJoin/package-standard10.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/companyMapWithoutJoin/package-standard9.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/companyMapWithoutJoin/package-standard9.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/converter/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/converter/package-standard.orm
@@ -15,11 +15,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
-  <package name="org.apache.jdo.tck.pc.converter">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
+<package name="org.apache.jdo.tck.pc.converter">
 
     <class name="PCRect" table="PCRectConv">
       <field name="id" column="ID"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/AllTypes-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/AllTypes-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="AllTypes" table="ALLTYPES">
             <field name="id" column="ID"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayCollections-standard.orm
@@ -18,10 +18,10 @@
 <!--
 Metadata for application identity
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="ArrayCollections" table="ARRAY_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayListCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayListCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="ArrayListCollections" table="ARRAYLIST_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/CollectionCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/CollectionCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="CollectionCollections" table="COLLECTION_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigDecimal-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigDecimal-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfBigDecimal" table="FIELDSOFBIGDECIMAL">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigInteger-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigInteger-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfBigInteger" table="FIELDSOFBIGINTEGER">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBoolean-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBoolean-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfBoolean" table="FIELDSOFBOOLEAN">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfByte-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfByte-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfByte" table="FieldsOfByte">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfCharacter-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfCharacter-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfCharacter" table="FIELDSOFCHARACTER">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDate-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDate-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfDate" table="FIELDSOFDATE">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDouble-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDouble-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfDouble" table="FIELDSOFDOUBLE">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfFloat-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfFloat-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfFloat" table="FIELDSOFFLOAT">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfInteger-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfInteger-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfInteger" table="FIELDSOFINTEGER">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLocale-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLocale-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfLocale" table="FIELDSOFLOCALE">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLong-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLong-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfLong" table="FIELDSOFLONG">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfObject-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfObject-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfObject" table="FIELDSOFOBJECT">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveboolean-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveboolean-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitiveboolean" table="FIELDSOFPRIMITIVEBOOLEAN">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivebyte-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivebyte-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivebyte" table="FIELDSOFPRIMITIVEBYTE">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivechar-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivechar-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivechar" table="FIELDSOFPRIMITIVECHAR">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivedouble-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivedouble-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivedouble" table="FIELDSOFPRIMITIVEDOUBLE">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivefloat-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivefloat-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivefloat" table="FIELDSOFPRIMITIVEFLOAT">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveint-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveint-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitiveint" table="FIELDSOFPRIMITIVEINT">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivelong-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivelong-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivelong" table="FIELDSOFPRIMITIVELONG">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveshort-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveshort-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitiveshort" table="FIELDSOFPRIMITIVESHORT">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfShort-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfShort-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
            <class name="FieldsOfShort" table="FIELDSOFSHORT">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleClass-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleClass-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfSimpleClass" table="FIELDSOFSIMPLECLASS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfSimpleEnum" table="FIELDSOFENUMNAME">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum-standard1.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum-standard1.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfSimpleEnum" table="FIELDSOFENUMORDINAL">
             <field name="identifier">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleInterface-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleInterface-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfSimpleInterface" table="FIELDSOFSIMPLEINTERFACE">
             <field name="identifier" column="IDENTIFIER">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfString-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfString-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfString" table="FIELDSOFSTRING">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringKeyCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringKeyCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashMapStringKeyCollections"
                table="HASHMAPSTRINGKEY_COLLECTIONS">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringValueCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringValueCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashMapStringValueCollections"
                table="HASHMAPSTRINGVALUE_COLLECTIONS">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashSetCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashSetCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashSetCollections" table="HASHSET_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringKeyCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringKeyCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashtableStringKeyCollections"
                table="HASHTABLESTRINGKEY_COLLECTIONS">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringValueCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringValueCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashtableStringValueCollections"
                table="HASHTBLSTRINGVALUE_COLLECTIONS">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/LinkedListCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/LinkedListCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="LinkedListCollections" table="LINKEDLIST_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ListCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/ListCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="ListCollections" table="LIST_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringKeyCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringKeyCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="MapStringKeyCollections" table="MAPSTRINGKEY_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringValueCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringValueCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="MapStringValueCollections"
                table="MAPSTRINGVALUE_COLLECTIONS">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/SetCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/SetCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="SetCollections" table="SET_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/SimpleClass-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/SimpleClass-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="SimpleClass" table="SIMPLE_CLASS">
             <field name="id" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringKeyCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringKeyCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="TreeMapStringKeyCollections"
                table="TREEMAPSTRINGKEY_COLLECTIONS">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringValueCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringValueCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="TreeMapStringValueCollections"
                table="TREEMAPSTRINGVALUE_COLLECTIONS">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeSetCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/TreeSetCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="TreeSetCollections" table="TREESET_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/VectorCollections-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/fieldtypes/VectorCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="VectorCollections" table="VECTOR_COLLECTIONS">
             <field name="identifier" column="IDENTIFIER"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/inheritance/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/inheritance/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.inheritance">
         <class name="AllPersist" table="AllPersist">
             <inheritance strategy="new-table">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/instancecallbacks/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/instancecallbacks/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.instancecallbacks">
         <class name="InstanceCallbackNonPersistFdsClass" table="ICNonPersistFds">
             <field name="keyValue">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.lifecycle">
     <class name="StateTransitionObj" table="STATETRANSITIONOBJ">
        <field name="id" column="ID"/>

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/mylib/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/mylib/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
 
     <class name="PCPoint" table="PCPoint">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/mylib/package-standard5.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/mylib/package-standard5.orm
@@ -16,10 +16,10 @@
   limitations under the License.
 -->
 <orm schema="applicationidentity_orm"
-     xmlns="http://java.sun.com/xml/ns/jdo/orm"
+     xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
 
     <class name="PCPoint" table="PCPoint">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/mylib/package-standard6.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/mylib/package-standard6.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib" schema="applicationidentity_pkg">
 
     <class name="PCPoint" table="PCPoint">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/mylib/package-standard7.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/mylib/package-standard7.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
 
     <class name="PCPoint" table="PCPoint" schema="applicationidentity_cls">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/newInstance/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/newInstance/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/order/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/order/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/query/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/query/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.query">
 
     <class name="JDOQLKeywordsAsFieldNames" table="JDOQLKeywordsAsFieldNames">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/shoppingcart/package-standard8.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/shoppingcart/package-standard8.orm
@@ -19,10 +19,10 @@
 This file contains the schema information when an implementation
 has application identity.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.shoppingcart">
 
         <class name="Cart" table="CARTS">

--- a/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/singlefieldidentity/package-standard.orm
+++ b/tck/src/main/resources/orm/applicationidentity/org/apache/jdo/tck/pc/singlefieldidentity/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.singlefieldidentity">
 
     <class name="PCPointSingleFieldPrimitivebyte" table="PCPointSingleFieldByte">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/api/instancecallbacks/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/api/instancecallbacks/package-standard.orm
@@ -19,10 +19,10 @@
 This file contains the schema information when an implementation
 has datastore identity.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.api.instancecallbacks">
 
         <class name="InstanceLifecycleListenerAttach$PC" 

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/building/package-standard12.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/building/package-standard12.orm
@@ -18,10 +18,10 @@
 <!--
 This file contains the schema information when an implementation has application-id.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.building" schema="datastoreidentity12">
 
         <sequence name="id_seq" datastore-sequence="DATASTORE_SEQ"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard1.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard1.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard2.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard2.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard3.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard3.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard4.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/company/package-standard4.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/companyAnnotatedFC/package-standard11.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/companyAnnotatedFC/package-standard11.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/companyListWithoutJoin/package-standard10.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/companyListWithoutJoin/package-standard10.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/companyMapWithoutJoin/package-standard9.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/companyMapWithoutJoin/package-standard9.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has application identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/converter/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/converter/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.converter">
 
     <class name="PCRect" table="PCRectConv">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/AllTypes-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/AllTypes-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="AllTypes" table="ALLTYPES">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayCollections-standard.orm
@@ -18,10 +18,10 @@
 <!--
 Metadata for datastore identity
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="ArrayCollections" table="ARRAY_COLLECTIONS">
             <datastore-identity strategy="identity"

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayListCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ArrayListCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="ArrayListCollections" table="ARRAYLIST_COLLECTIONS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/CollectionCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/CollectionCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="CollectionCollections" table="COLLECTION_COLLECTIONS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigDecimal-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigDecimal-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfBigDecimal" table="FIELDSOFBIGDECIMAL">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigInteger-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBigInteger-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfBigInteger" table="FIELDSOFBIGINTEGER">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBoolean-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfBoolean-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfBoolean" table="FIELDSOFBOOLEAN">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfByte-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfByte-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfByte" table="FieldsOfByte">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfCharacter-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfCharacter-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfCharacter" table="FIELDSOFCHARACTER">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDate-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDate-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfDate" table="FIELDSOFDATE">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDouble-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfDouble-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfDouble" table="FIELDSOFDOUBLE">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfFloat-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfFloat-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfFloat" table="FIELDSOFFLOAT">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfInteger-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfInteger-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfInteger" table="FIELDSOFINTEGER">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLocale-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLocale-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfLocale" table="FIELDSOFLOCALE">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLong-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfLong-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfLong" table="FIELDSOFLONG">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfObject-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfObject-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfObject" table="FIELDSOFOBJECT">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveboolean-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveboolean-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitiveboolean" table="FIELDSOFPRIMITIVEBOOLEAN">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivebyte-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivebyte-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivebyte" table="FIELDSOFPRIMITIVEBYTE">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivechar-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivechar-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivechar" table="FIELDSOFPRIMITIVECHAR">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivedouble-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivedouble-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivedouble" table="FIELDSOFPRIMITIVEDOUBLE">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivefloat-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivefloat-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivefloat" table="FIELDSOFPRIMITIVEFLOAT">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveint-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveint-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitiveint" table="FIELDSOFPRIMITIVEINT">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivelong-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitivelong-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitivelong" table="FIELDSOFPRIMITIVELONG">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveshort-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfPrimitiveshort-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfPrimitiveshort" table="FIELDSOFPRIMITIVESHORT">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfShort-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfShort-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
            <class name="FieldsOfShort" table="FIELDSOFSHORT">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleClass-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleClass-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfSimpleClass" table="FIELDSOFSIMPLECLASS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfSimpleEnum" table="FIELDSOFENUMNAME">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum-standard1.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleEnum-standard1.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfSimpleEnum" table="FIELDSOFENUMORDINAL">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleInterface-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfSimpleInterface-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfSimpleInterface" table="FIELDSOFSIMPLEINTERFACE">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfString-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/FieldsOfString-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="FieldsOfString" table="FIELDSOFSTRING">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringKeyCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringKeyCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashMapStringKeyCollections"
                table="HASHMAPSTRINGKEY_COLLECTIONS">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringValueCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashMapStringValueCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashMapStringValueCollections"
                table="HASHMAPSTRINGVALUE_COLLECTIONS">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashSetCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashSetCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashSetCollections" table="HASHSET_COLLECTIONS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringKeyCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringKeyCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashtableStringKeyCollections"
                table="HASHTABLESTRINGKEY_COLLECTIONS">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringValueCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/HashtableStringValueCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="HashtableStringValueCollections"
                table="HASHTBLSTRINGVALUE_COLLECTIONS">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/LinkedListCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/LinkedListCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="LinkedListCollections" table="LINKEDLIST_COLLECTIONS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ListCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/ListCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="ListCollections" table="LIST_COLLECTIONS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringKeyCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringKeyCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="MapStringKeyCollections" table="MAPSTRINGKEY_COLLECTIONS">
             <datastore-identity strategy="identity"

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringValueCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/MapStringValueCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="MapStringValueCollections"
                table="MAPSTRINGVALUE_COLLECTIONS">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/SetCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/SetCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="SetCollections" table="SET_COLLECTIONS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/SimpleClass-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/SimpleClass-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="SimpleClass" table="SIMPLE_CLASS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringKeyCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringKeyCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="TreeMapStringKeyCollections"
                table="TREEMAPSTRINGKEY_COLLECTIONS">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringValueCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeMapStringValueCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="TreeMapStringValueCollections"
                table="TREEMAPSTRINGVALUE_COLLECTIONS">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeSetCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/TreeSetCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="TreeSetCollections" table="TREESET_COLLECTIONS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/VectorCollections-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/fieldtypes/VectorCollections-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.fieldtypes">
         <class name="VectorCollections" table="VECTOR_COLLECTIONS">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/inheritance/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/inheritance/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.inheritance">
         <class name="AllPersist" table="AllPersist">
             <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/instancecallbacks/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/instancecallbacks/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.instancecallbacks">
         <class name="InstanceCallbackNonPersistFdsClass" table="ICNonPersistFds">
             <datastore-identity strategy="identity">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.lifecycle">
     <class name="StateTransitionObj" table="STATETRANSITIONOBJ">
        <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/mylib/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/mylib/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
 
     <class name="PCPoint" table="PCPoint">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/mylib/package-standard5.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/mylib/package-standard5.orm
@@ -16,10 +16,10 @@
   limitations under the License.
 -->
 <orm schema="datastoreidentity_orm"
-     xmlns="http://java.sun.com/xml/ns/jdo/orm"
+     xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
 
     <class name="PCPoint" table="PCPoint">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/mylib/package-standard6.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/mylib/package-standard6.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib" schema="datastoreidentity_pkg" >
 
     <class name="PCPoint" table="PCPoint">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/mylib/package-standard7.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/mylib/package-standard7.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.mylib">
 
     <class name="PCPoint" table="PCPoint" schema="datastoreidentity_cls">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/newInstance/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/newInstance/package-standard.orm
@@ -15,10 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
 <!--
 This file contains the schema information when an implementation
 has datastore identity.

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/query/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/query/package-standard.orm
@@ -18,10 +18,10 @@
 <!--
 This file contains the schema information when an implementation has datastore identity.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
   <package name="org.apache.jdo.tck.pc.query">
 
     <class name="JDOQLKeywordsAsFieldNames" table="JDOQLKeywordsAsFieldNames">

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/shoppingcart/package-standard8.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/shoppingcart/package-standard8.orm
@@ -19,10 +19,10 @@
 This file contains the schema information when an implementation
 has datastore identity.
 -->
-<orm xmlns="http://java.sun.com/xml/ns/jdo/orm"
+<orm xmlns="http://xmlns.jcp.org/xml/ns/jdo/orm"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/jdo/orm 
-	http://java.sun.com/xml/ns/jdo/orm_2_1.xsd">
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/jdo/orm
+     http://xmlns.jcp.org/xml/ns/jdo/orm_3_2.xsd">
     <package name="org.apache.jdo.tck.pc.shoppingcart" schema="datastoreidentity8">
 
         <sequence name="id_seq" datastore-sequence="DATASTORE_SEQ"/>


### PR DESCRIPTION
Make use of latest 3.2 xsd and dtd definition.

This PR includes changes in the api module (test resources) and changes in the tck module.


