### PR TITLE
upgrade Felix maven-bundle-plugin

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -282,7 +282,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.4</version>
+                    <version>5.1.6</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
release 3.2.1 suffers from a reproducibility issue that was fixed in Felix bundle plugin 5.1.6...

see https://github.com/jvm-repo-rebuild/reproducible-central/tree/master/content/org/apache/jdo