### PR TITLE
[JDO-709] Enable Element.TYPE for @Convert

### DIFF
--- a/api/src/main/java/javax/jdo/annotations/Convert.java
+++ b/api/src/main/java/javax/jdo/annotations/Convert.java
@@ -37,7 +37,7 @@ import javax.jdo.AttributeConverter;
  * @since 3.2
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 public @interface Convert {
 
   /**


### PR DESCRIPTION
This reverts commit bddffaba0384d1393b9091461ad9eaba0d9848b8 to be consistent with its javadoc.

With this capability, we can avoid as much configuration file as possible, it's very convenient to mark default attribute converter for a type with Java annotation.

Reference: https://issues.apache.org/jira/browse/JDO-709?focusedCommentId=17619585&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17619585