### PR TITLE
[JDO-709] Enable Element.TYPE for @Convert - TCK test

### DIFF
--- a/api/src/main/java/javax/jdo/annotations/Convert.java
+++ b/api/src/main/java/javax/jdo/annotations/Convert.java
@@ -37,7 +37,7 @@ import javax.jdo.AttributeConverter;
  * @since 3.2
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 public @interface Convert {
 
   /**

--- a/tck/src/main/java/org/apache/jdo/tck/api/converter/PointAttributeConverterTest.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/converter/PointAttributeConverterTest.java
@@ -25,6 +25,7 @@ import org.apache.jdo.tck.JDO_Test;
 import org.apache.jdo.tck.pc.converter.IPCRect;
 import org.apache.jdo.tck.pc.converter.PCRect;
 import org.apache.jdo.tck.pc.converter.PCRectAnnotated;
+import org.apache.jdo.tck.pc.converter.PCRectPointTypeAnnotated;
 import org.apache.jdo.tck.pc.mylib.Point;
 import org.apache.jdo.tck.util.BatchTestRunner;
 import org.apache.jdo.tck.util.PointToStringConverter;
@@ -109,6 +110,31 @@ public class PointAttributeConverterTest extends JDO_Test {
   /** Test method running a PCRectStringAnnotated query with a query parameter of type Point. */
   public void testPCRectStringAnnotatedQueryWithStringParam() throws Exception {
     runQueryWithStringParameter(PCRectAnnotated.class);
+  }
+
+  /** Test method creating and storing a PCRectStringAnnotated instance. */
+  public void testStorePCRectPointTypeAnnotatedInstance() {
+    runStoreIPCRectInstance(PCRectPointTypeAnnotated.class);
+  }
+
+  /** Test method reading a PCRectStringAnnotated instance from the datastore. */
+  public void testReadPCRectPointTypeAnnotatedInstance() {
+    runReadIPCRectInstance(PCRectPointTypeAnnotated.class);
+  }
+
+  /** Test method modifying a PCRectStringAnnotated instance and storing in the datastore. */
+  public void testModifyPCRectPointTypeAnnotatedInstance() {
+    runModifyIPCRectInstance(PCRectPointTypeAnnotated.class);
+  }
+
+  /** Test method running a PCRectStringAnnotated query with a query parameter of type String. */
+  public void testPCRectPointTypeAnnotatedQueryWithPointParam() {
+    runQueryWithPointParameter(PCRectPointTypeAnnotated.class);
+  }
+
+  /** Test method running a PCRectStringAnnotated query with a query parameter of type Point. */
+  public void testPCRectPointTypeAnnotatedQueryWithStringParam() throws Exception {
+    runQueryWithStringParameter(PCRectPointTypeAnnotated.class);
   }
 
   // Helper methods

--- a/tck/src/main/java/org/apache/jdo/tck/pc/converter/PCRectPointTypeAnnotated.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/converter/PCRectPointTypeAnnotated.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jdo.tck.pc.converter;
+
+import org.apache.jdo.tck.pc.mylib.ConvertiblePoint;
+import org.apache.jdo.tck.pc.mylib.Point;
+import org.apache.jdo.tck.util.PointToStringConverter;
+
+import javax.jdo.annotations.Column;
+import javax.jdo.annotations.Convert;
+import javax.jdo.annotations.PersistenceCapable;
+import java.util.Date;
+
+/**
+ * PersistenceCapable class to test JDO AttributeConverter interface. Its fields of type Point are
+ * converted to strings in the datastore.
+ * The conversion is declared directly on the type ConvertiblePoint.
+ */
+@PersistenceCapable(table = "PCRectConv")
+public class PCRectPointTypeAnnotated implements IPCRect {
+  private static long counter = new Date().getTime();
+
+  private static synchronized long newId() {
+    return counter++;
+  }
+
+  @Column(name = "ID")
+  private long id = newId();
+
+  @Column(name = "UPPER_LEFT")
+  private ConvertiblePoint upperLeft;
+
+  @Column(name = "LOWER_RIGHT")
+  private ConvertiblePoint lowerRight;
+
+  public PCRectPointTypeAnnotated() {}
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public Point getUpperLeft() {
+    return new Point(upperLeft.getX(), upperLeft.getY());
+  }
+
+  public void setUpperLeft(Point upperLeft) {
+    if (this.upperLeft == null) {
+      this.upperLeft = new ConvertiblePoint(upperLeft.getX(), upperLeft.getY());
+    } else {
+      this.upperLeft.setX(upperLeft.getX());
+      this.upperLeft.setY(upperLeft.getY());
+    }
+  }
+
+  public Point getLowerRight() {
+    return new Point(lowerRight.getX(), lowerRight.getY());
+  }
+
+  public void setLowerRight(Point lowerRight) {
+    if (this.lowerRight == null) {
+      this.lowerRight = new ConvertiblePoint(lowerRight.getX(), lowerRight.getY());
+    } else {
+      this.lowerRight.setX(lowerRight.getX());
+      this.lowerRight.setY(lowerRight.getY());
+    }
+  }
+
+  public String toString() {
+    String rc = null;
+    Object obj = this;
+    try {
+      rc =
+          obj.getClass().getName()
+              + " ul: "
+              + getUpperLeft().name()
+              + " lr: "
+              + getLowerRight().name();
+    } catch (NullPointerException ex) {
+      rc = "NPE getting PCRectPointTypeAnnotated's values";
+    }
+    return rc;
+  }
+}

--- a/tck/src/main/java/org/apache/jdo/tck/pc/mylib/ConvertiblePoint.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/mylib/ConvertiblePoint.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jdo.tck.pc.mylib;
+
+import org.apache.jdo.tck.util.PointToStringConverter;
+
+import javax.jdo.annotations.Convert;
+
+/**
+ * A simple point class with two fields. The whole class/type is declared convertible.
+ */
+@Convert(value = PointToStringConverter.class)
+public class ConvertiblePoint {
+  public int x;
+  public Integer y;
+
+  public ConvertiblePoint() {}
+
+  public ConvertiblePoint(int x, int y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  public ConvertiblePoint(int x, Integer y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  public String toString() {
+    String rc = null;
+    try {
+      rc = "Point(" + name() + ")";
+    } catch (NullPointerException ex) {
+      rc = "NPE getting Point's values";
+    }
+    return rc;
+  }
+
+  public int getX() {
+    System.out.println("Hello from Point.getX");
+    return x;
+  }
+
+  public Integer getY() {
+    System.out.println("Hello from Point.getY");
+    return y;
+  }
+
+  public void setX(int x) {
+    this.x = x;
+  }
+
+  public void setY(int y) {
+    this.y = y;
+  }
+
+  public String name() {
+    return "x: " + getX() + ", y: " + getY();
+  }
+}

--- a/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/converter/package.jdo
+++ b/tck/src/main/resources/jdo/applicationidentity/org/apache/jdo/tck/pc/converter/package.jdo
@@ -33,6 +33,11 @@
       <field name="id" primary-key="true"/>
     </class>
 
+    <class name="PCRectPointTypeAnnotated"
+           identity-type="application" objectid-class="javax.jdo.identity.LongIdentity">
+      <field name="id" primary-key="true"/>
+    </class>
+
     <class name="PCPoint"
            identity-type="application" objectid-class="javax.jdo.identity.LongIdentity">
       <field name="id" primary-key="true"/>

--- a/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/converter/package.jdo
+++ b/tck/src/main/resources/jdo/datastoreidentity/org/apache/jdo/tck/pc/converter/package.jdo
@@ -27,6 +27,7 @@
     </class>
 
     <class name="PCRectAnnotated" identity-type="datastore"/>
+    <class name="PCRectPointTypeAnnotated" identity-type="datastore"/>
 
     <class name="PCPoint" identity-type="datastore">
       <field name="x" converter="org.apache.jdo.tck.util.IntegerToStringConverter"/>
@@ -34,6 +35,7 @@
     </class>
 
     <class name="PCPointAnnotated" identity-type="datastore"/>
+    <class name="PCRectPointTypeAnnotated" identity-type="datastore"/>
 
     <class name="PCPointProp" identity-type="datastore">
       <property name="x" converter="org.apache.jdo.tck.util.IntegerToStringConverter"/>

--- a/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/converter/package-standard.orm
+++ b/tck/src/main/resources/orm/datastoreidentity/org/apache/jdo/tck/pc/converter/package-standard.orm
@@ -32,6 +32,10 @@
       <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>
     </class>
 
+    <class name="PCRectPointTypeAnnotated">
+      <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>
+    </class>
+
     <class name="PCPoint" table="PCPointConv">
       <datastore-identity strategy="identity" column="DATASTORE_IDENTITY"/>
       <field name="id" column="ID"/>


### PR DESCRIPTION
This PR is based on PR #60 . This PR adds `@Convert` tests to the `PointAttributeConverterTest` in the TCK.

The convertible point class is called `ConvertiblePoint` and is used in a new persistent class is `PCRectPointTypeAnnotated`.

Questions: 
* Does the converter or the convertible class need to be declared in one of the `.jdo` or `.orm` files?
* Do we need to initialize the `ConvertiblePoint` fields in `PCRectPointTypeAnnotated`?

Current status: The test fails. It appears that the converter is not called.
* Apparently the fields do not get initialized
* Even when they are initialized, they don't appear to get stored/loaded.



[dsid-converter-junit.txt](https://github.com/apache/db-jdo/files/9997874/dsid-converter-junit.txt)

[dsid-converter-tck.txt](https://github.com/apache/db-jdo/files/9997875/dsid-converter-tck.txt)
