### PR TITLE
Review security issues raised by SonarCloud

### DIFF
--- a/api/src/main/java/javax/jdo/LegacyJava.java
+++ b/api/src/main/java/javax/jdo/LegacyJava.java
@@ -76,7 +76,6 @@ public class LegacyJava {
     try {
       sm = getSecurityManager.invoke(null);
     } catch (IllegalAccessException | InvocationTargetException e) {
-      e.printStackTrace();
       throw new JDOFatalInternalException(e.getMessage());
     }
     if (sm == null) {
@@ -107,7 +106,6 @@ public class LegacyJava {
       try {
         checkPermissionMethod.invoke(null, permission);
       } catch (IllegalAccessException | InvocationTargetException e) {
-        e.printStackTrace();
         throw new JDOFatalInternalException(e.getMessage());
       }
     }


### PR DESCRIPTION
SonarCloud raised several possible security issues related to use of `printStackTrace()`.
After review, they were all deemed (and labelled) safe.
In addition this patch removes two uses of `printStackTrace()`.

See https://issues.apache.org/jira/projects/JDO/issues/JDO-821