### PR TITLE
Clarify javadoc of Query.cancel() and cancelAll()

### DIFF
--- a/api/src/main/java/javax/jdo/Query.java
+++ b/api/src/main/java/javax/jdo/Query.java
@@ -87,7 +87,7 @@ import java.util.Map;
  * and are not remembered for future execution.
  *
  * @version 2.1
- * @param T Candidate class for the query
+ * @param <T> Candidate class for the query
  */
 public interface Query<T> extends AutoCloseable, Serializable {
 

--- a/api/src/main/java/javax/jdo/Query.java
+++ b/api/src/main/java/javax/jdo/Query.java
@@ -768,8 +768,8 @@ public interface Query<T> extends AutoCloseable, Serializable {
   void cancelAll();
 
   /**
-   * Method to cancel any executions of this query instance that run in the specified thread. If the
-   * underlying datastore doesn't support cancellation of queries this will throw
+   * Method to cancel an execution of this query in the parameter thread. If the underlying
+   * datastore doesn't support cancellation of queries this will throw
    * JDOUnsupportedOptionException. If the cancellation fails (e.g in the underlying datastore) then
    * this will throw a JDOException.
    *

--- a/api/src/main/java/javax/jdo/Query.java
+++ b/api/src/main/java/javax/jdo/Query.java
@@ -768,9 +768,10 @@ public interface Query<T> extends AutoCloseable, Serializable {
   void cancelAll();
 
   /**
-   * Method to cancel an executing query in the specified thread. If the underlying datastore
-   * doesn't support cancellation of queries this will throw JDOUnsupportedOptionException. If the
-   * cancellation fails (e.g in the underlying datastore) then this will throw a JDOException.
+   * Method to cancel any executions of this query instance that run in the specified thread. If the
+   * underlying datastore doesn't support cancellation of queries this will throw
+   * JDOUnsupportedOptionException. If the cancellation fails (e.g in the underlying datastore) then
+   * this will throw a JDOException.
    *
    * @param thread The thread to cancel
    * @since 3.0

--- a/api/src/main/java/javax/jdo/Query.java
+++ b/api/src/main/java/javax/jdo/Query.java
@@ -759,7 +759,8 @@ public interface Query<T> extends AutoCloseable, Serializable {
   Integer getDatastoreWriteTimeoutMillis();
 
   /**
-   * Method to cancel any executing queries. If the underlying datastore doesn't support
+   * Method to cancel all executions of this query instance.
+   * If the underlying datastore doesn't support
    * cancellation of queries this will throw JDOUnsupportedOptionException. If the cancellation
    * fails (e.g in the underlying datastore) then this will throw a JDOException.
    *

--- a/api/src/main/java/javax/jdo/Query.java
+++ b/api/src/main/java/javax/jdo/Query.java
@@ -759,10 +759,9 @@ public interface Query<T> extends AutoCloseable, Serializable {
   Integer getDatastoreWriteTimeoutMillis();
 
   /**
-   * Method to cancel all executions of this query instance.
-   * If the underlying datastore doesn't support
-   * cancellation of queries this will throw JDOUnsupportedOptionException. If the cancellation
-   * fails (e.g in the underlying datastore) then this will throw a JDOException.
+   * Method to cancel all executions of this query instance. If the underlying datastore doesn't
+   * support cancellation of queries this will throw JDOUnsupportedOptionException. If the
+   * cancellation fails (e.g in the underlying datastore) then this will throw a JDOException.
    *
    * @since 3.0
    */


### PR DESCRIPTION
Clarify javadoc of Query.cancel() and cancelAll().

This PR suggest a clarification of the javadoc, see https://issues.apache.org/jira/browse/JDO-838.

**Comment**: I actually changed my mind and would suggest to _not_ change the javadoc. In hindsight it seems quite clear.