### PR TITLE
JDO-845: Update JDO dependencies

### DIFF
--- a/api/src/main/java/javax/jdo/Constants.java
+++ b/api/src/main/java/javax/jdo/Constants.java
@@ -108,126 +108,147 @@ public interface Constants {
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_CLASS = "class";
+
   /**
    * The name of the persistence manager factory element's "name" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_NAME = "name";
+
   /**
    * The name of the persistence manager factory element's "persistence-unit-name" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_PERSISTENCE_UNIT_NAME = "persistence-unit-name";
+
   /**
    * The name of the persistence manager factory element's "optimistic" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_OPTIMISTIC = "optimistic";
+
   /**
    * The name of the persistence manager factory element's "readonly" attribute.
    *
    * @since 2.2
    */
   static String PMF_ATTRIBUTE_READONLY = "readonly";
+
   /**
    * The name of the persistence manager factory element's "retain-values" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_RETAIN_VALUES = "retain-values";
+
   /**
    * The name of the persistence manager factory element's "restore-values" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_RESTORE_VALUES = "restore-values";
+
   /**
    * The name of the persistence manager factory element's "ignore-cache" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_IGNORE_CACHE = "ignore-cache";
+
   /**
    * The name of the persistence manager factory element's "nontransactional-read" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_NONTRANSACTIONAL_READ = "nontransactional-read";
+
   /**
    * The name of the persistence manager factory element's "nontransactional-write" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_NONTRANSACTIONAL_WRITE = "nontransactional-write";
+
   /**
    * The name of the persistence manager factory element's "multithreaded" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_MULTITHREADED = "multithreaded";
+
   /**
    * The name of the persistence manager factory element's "connection-driver-name" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_CONNECTION_DRIVER_NAME = "connection-driver-name";
+
   /**
    * The name of the persistence manager factory element's "connection-user-name" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_CONNECTION_USER_NAME = "connection-user-name";
+
   /**
    * The name of the persistence manager factory element's "connection-password" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_CONNECTION_PASSWORD = "connection-password";
+
   /**
    * The name of the persistence manager factory element's "connection-url" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_CONNECTION_URL = "connection-url";
+
   /**
    * The name of the persistence manager factory element's "connection-factory-name" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_CONNECTION_FACTORY_NAME = "connection-factory-name";
+
   /**
    * The name of the persistence manager factory element's "connection-factory2-name" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_CONNECTION_FACTORY2_NAME = "connection-factory2-name";
+
   /**
    * The name of the persistence manager factory element's "detach-all-on-commit" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_DETACH_ALL_ON_COMMIT = "detach-all-on-commit";
+
   /**
    * The name of the persistence manager factory element's "copy-on-attach" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_COPY_ON_ATTACH = "copy-on-attach";
+
   /**
    * The name of the persistence manager factory element's "mapping" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_MAPPING = "mapping";
+
   /**
    * The name of the persistence manager factory element's "server-time-zone-id" attribute.
    *
    * @since 2.1
    */
   static String PMF_ATTRIBUTE_SERVER_TIME_ZONE_ID = "server-time-zone-id";
+
   /**
    * The name of the persistence manager factory element's "datastore-read-timeout-millis"
    * attribute.
@@ -235,6 +256,7 @@ public interface Constants {
    * @since 3.0
    */
   static String PMF_ATTRIBUTE_DATASTORE_READ_TIMEOUT_MILLIS = "datastore-read-timeout-millis";
+
   /**
    * The name of the persistence manager factory element's "datastore-write-timeout-millis"
    * attribute.
@@ -242,12 +264,15 @@ public interface Constants {
    * @since 3.0
    */
   static String PMF_ATTRIBUTE_DATASTORE_WRITE_TIMEOUT_MILLIS = "datastore-write-timeout-millis";
+
   /**
    * The name of the persistence manager factory property elements in the JDO configuration file.
    */
   static String ELEMENT_PROPERTY = "property";
+
   /** The name of the persistence manager factory property element's "name" attribute. */
   static String PROPERTY_ATTRIBUTE_NAME = "name";
+
   /** The name of the persistence manager factory property element's "value" attribute. */
   static String PROPERTY_ATTRIBUTE_VALUE = "value";
 
@@ -256,6 +281,7 @@ public interface Constants {
 
   /** The name of the instance lifecycle listener element's "listener" attribute. */
   static String INSTANCE_LIFECYCLE_LISTENER_ATTRIBUTE_LISTENER = "listener";
+
   /** The name of the instance lifecycle listener element's "classes" attribute. */
   static String INSTANCE_LIFECYCLE_LISTENER_ATTRIBUTE_CLASSES = "classes";
 
@@ -266,6 +292,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_TRANSACTIONAL_TRANSIENT = "javax.jdo.option.TransientTransactional";
+
   /**
    * "javax.jdo.option.NontransactionalRead"
    *
@@ -273,6 +300,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_NONTRANSACTIONAL_READ = "javax.jdo.option.NontransactionalRead";
+
   /**
    * "javax.jdo.option.NontransactionalWrite"
    *
@@ -280,6 +308,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_NONTRANSACTIONAL_WRITE = "javax.jdo.option.NontransactionalWrite";
+
   /**
    * "javax.jdo.option.RetainValues"
    *
@@ -287,6 +316,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_RETAIN_VALUES = "javax.jdo.option.RetainValues";
+
   /**
    * "javax.jdo.option.Optimistic"
    *
@@ -294,6 +324,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_OPTIMISTIC = "javax.jdo.option.Optimistic";
+
   /**
    * "javax.jdo.option.ApplicationIdentity"
    *
@@ -301,6 +332,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_APPLICATION_IDENTITY = "javax.jdo.option.ApplicationIdentity";
+
   /**
    * "javax.jdo.option.DatastoreIdentity"
    *
@@ -308,6 +340,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_DATASTORE_IDENTITY = "javax.jdo.option.DatastoreIdentity";
+
   /**
    * "javax.jdo.option.NonDurableIdentity"
    *
@@ -315,6 +348,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_NONDURABLE_IDENTITY = "javax.jdo.option.NonDurableIdentity";
+
   /**
    * "javax.jdo.option.ArrayList"
    *
@@ -322,6 +356,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_ARRAYLIST = "javax.jdo.option.ArrayList";
+
   /**
    * "javax.jdo.option.LinkedList"
    *
@@ -329,6 +364,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_LINKEDLIST = "javax.jdo.option.LinkedList";
+
   /**
    * "javax.jdo.option.TreeMap"
    *
@@ -336,6 +372,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_TREEMAP = "javax.jdo.option.TreeMap";
+
   /**
    * "javax.jdo.option.TreeSet"
    *
@@ -343,6 +380,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_TREESET = "javax.jdo.option.TreeSet";
+
   /**
    * "javax.jdo.option.Vector"
    *
@@ -350,6 +388,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_VECTOR = "javax.jdo.option.Vector";
+
   /**
    * "javax.jdo.option.Array"
    *
@@ -357,6 +396,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_ARRAY = "javax.jdo.option.Array";
+
   /**
    * "javax.jdo.option.NullCollection"
    *
@@ -364,6 +404,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_NULL_COLLECTION = "javax.jdo.option.NullCollection";
+
   /**
    * "javax.jdo.option.ChangeApplicationIdentity"
    *
@@ -371,6 +412,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_CHANGE_APPLICATION_IDENTITY = "javax.jdo.option.ChangeApplicationIdentity";
+
   /**
    * "javax.jdo.option.BinaryCompatibility"
    *
@@ -378,6 +420,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_BINARY_COMPATIBILITY = "javax.jdo.option.BinaryCompatibility";
+
   /**
    * "javax.jdo.option.GetDataStoreConnection"
    *
@@ -385,6 +428,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_GET_DATASTORE_CONNECTION = "javax.jdo.option.GetDataStoreConnection";
+
   /**
    * "javax.jdo.option.GetJDBCConnection"
    *
@@ -392,6 +436,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_GET_JDBC_CONNECTION = "javax.jdo.option.GetJDBCConnection";
+
   /**
    * "javax.jdo.query.SQL"
    *
@@ -432,6 +477,7 @@ public interface Constants {
    * @since 3.0
    */
   static String OPTION_DATASTORE_TIMEOUT = "javax.jdo.option.DatastoreTimeout";
+
   /**
    * "javax.jdo.option.version.DateTime"
    *
@@ -439,6 +485,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_VERSION_DATETIME = "javax.jdo.option.version.DateTime";
+
   /**
    * "javax.jdo.option.version.StateImage"
    *
@@ -446,6 +493,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_VERSION_STATE_IMAGE = "javax.jdo.option.version.StateImage";
+
   /**
    * "javax.jdo.option.PreDirtyEvent"
    *
@@ -453,6 +501,7 @@ public interface Constants {
    * @since 2.1
    */
   static String OPTION_PREDIRTY_EVENT = "javax.jdo.option.PreDirtyEvent";
+
   /**
    * "javax.jdo.option.mapping.HeterogeneousObjectType"
    *
@@ -461,6 +510,7 @@ public interface Constants {
    */
   static String OPTION_MAPPING_HETEROGENEOUS_OBJECT_TYPE =
       "javax.jdo.option.mapping.HeterogeneousObjectType";
+
   /**
    * "javax.jdo.option.mapping.HeterogeneousInterfaceType"
    *
@@ -469,6 +519,7 @@ public interface Constants {
    */
   static String OPTION_MAPPING_HETEROGENEOUS_INTERFACE_TYPE =
       "javax.jdo.option.mapping.HeterogeneousInterfaceType";
+
   /**
    * "javax.jdo.option.mapping.JoinedTablePerClass"
    *
@@ -477,6 +528,7 @@ public interface Constants {
    */
   static String OPTION_MAPPING_JOINED_TABLE_PER_CLASS =
       "javax.jdo.option.mapping.JoinedTablePerClass";
+
   /**
    * "javax.jdo.option.mapping.JoinedTablePerConcreteClass"
    *
@@ -485,6 +537,7 @@ public interface Constants {
    */
   static String OPTION_MAPPING_JOINED_TABLE_PER_CONCRETE_CLASS =
       "javax.jdo.option.mapping.JoinedTablePerConcreteClass";
+
   /**
    * "javax.jdo.option.mapping.NonJoinedTablePerConcreteClass"
    *
@@ -493,6 +546,7 @@ public interface Constants {
    */
   static String OPTION_MAPPING_NON_JOINED_TABLE_PER_CONCRETE_CLASS =
       "javax.jdo.option.mapping.NonJoinedTablePerConcreteClass";
+
   /**
    * "javax.jdo.option.mapping.RelationSubclassTable"
    *
@@ -555,6 +609,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_OPTIMISTIC = "javax.jdo.option.Optimistic";
+
   /**
    * "javax.jdo.option.ReadOnly"
    *
@@ -562,6 +617,7 @@ public interface Constants {
    * @since 2.2
    */
   static String PROPERTY_READONLY = "javax.jdo.option.ReadOnly";
+
   /**
    * "javax.jdo.option.RetainValues"
    *
@@ -569,6 +625,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_RETAIN_VALUES = "javax.jdo.option.RetainValues";
+
   /**
    * "javax.jdo.option.RestoreValues"
    *
@@ -576,6 +633,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_RESTORE_VALUES = "javax.jdo.option.RestoreValues";
+
   /**
    * "javax.jdo.option.IgnoreCache"
    *
@@ -583,6 +641,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_IGNORE_CACHE = "javax.jdo.option.IgnoreCache";
+
   /**
    * "javax.jdo.option.NontransactionalRead"
    *
@@ -590,6 +649,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_NONTRANSACTIONAL_READ = "javax.jdo.option.NontransactionalRead";
+
   /**
    * "javax.jdo.option.NontransactionalWrite"
    *
@@ -597,6 +657,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_NONTRANSACTIONAL_WRITE = "javax.jdo.option.NontransactionalWrite";
+
   /**
    * "javax.jdo.option.Multithreaded"
    *
@@ -604,12 +665,14 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_MULTITHREADED = "javax.jdo.option.Multithreaded";
+
   /**
    * "javax.jdo.option.TransactionIsolationLevel"
    *
    * @since 2.2
    */
   static String PROPERTY_TRANSACTION_ISOLATION_LEVEL = "javax.jdo.option.TransactionIsolationLevel";
+
   /**
    * "javax.jdo.option.TransactionIsolationLevel.read-uncommitted"
    *
@@ -618,6 +681,7 @@ public interface Constants {
    */
   static String PROPERTY_TRANSACTION_ISOLATION_LEVEL_READ_UNCOMMITTED =
       "javax.jdo.option.TransactionIsolationLevel.read-uncommitted";
+
   /**
    * "javax.jdo.option.TransactionIsolationLevel.read-committed"
    *
@@ -626,6 +690,7 @@ public interface Constants {
    */
   static String PROPERTY_TRANSACTION_ISOLATION_LEVEL_READ_COMMITTED =
       "javax.jdo.option.TransactionIsolationLevel.read-committed";
+
   /**
    * "javax.jdo.option.TransactionIsolationLevel.repeatable-read"
    *
@@ -634,6 +699,7 @@ public interface Constants {
    */
   static String PROPERTY_TRANSACTION_ISOLATION_LEVEL_REPEATABLE_READ =
       "javax.jdo.option.TransactionIsolationLevel.repeatable-read";
+
   /**
    * "javax.jdo.option.TransactionIsolationLevel.snapshot"
    *
@@ -642,6 +708,7 @@ public interface Constants {
    */
   static String PROPERTY_TRANSACTION_ISOLATION_LEVEL_SNAPSHOT =
       "javax.jdo.option.TransactionIsolationLevel.snapshot";
+
   /**
    * "javax.jdo.option.TransactionIsolationLevel.serializable"
    *
@@ -650,6 +717,7 @@ public interface Constants {
    */
   static String PROPERTY_TRANSACTION_ISOLATION_LEVEL_SERIALIZABLE =
       "javax.jdo.option.TransactionIsolationLevel.serializable";
+
   /**
    * "javax.jdo.option.DetachAllOnCommit"
    *
@@ -657,6 +725,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_DETACH_ALL_ON_COMMIT = "javax.jdo.option.DetachAllOnCommit";
+
   /**
    * "javax.jdo.option.CopyOnAttach"
    *
@@ -664,6 +733,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_COPY_ON_ATTACH = "javax.jdo.option.CopyOnAttach";
+
   /**
    * "javax.jdo.option.ConnectionDriverName" This property might be ignored by the JDO
    * implementation because the JDBC DriverManager handles the driver name.
@@ -672,6 +742,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_CONNECTION_DRIVER_NAME = "javax.jdo.option.ConnectionDriverName";
+
   /**
    * "javax.jdo.option.ConnectionUserName"
    *
@@ -679,12 +750,14 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_CONNECTION_USER_NAME = "javax.jdo.option.ConnectionUserName";
+
   /**
    * "javax.jdo.option.Password"
    *
    * @since 2.1
    */
   static String PROPERTY_CONNECTION_PASSWORD = "javax.jdo.option.ConnectionPassword";
+
   /**
    * "javax.jdo.option.ConnectionURL"
    *
@@ -692,6 +765,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_CONNECTION_URL = "javax.jdo.option.ConnectionURL";
+
   /**
    * "javax.jdo.option.ConnectionFactoryName"
    *
@@ -699,6 +773,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_CONNECTION_FACTORY_NAME = "javax.jdo.option.ConnectionFactoryName";
+
   /**
    * "javax.jdo.option.ConnectionFactory2Name"
    *
@@ -706,6 +781,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_CONNECTION_FACTORY2_NAME = "javax.jdo.option.ConnectionFactory2Name";
+
   /**
    * "javax.jdo.option.Mapping"
    *
@@ -713,6 +789,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_MAPPING = "javax.jdo.option.Mapping";
+
   /**
    * "javax.jdo.option.PersistenceUnitName"
    *
@@ -720,6 +797,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_PERSISTENCE_UNIT_NAME = "javax.jdo.option.PersistenceUnitName";
+
   /**
    * "javax.jdo.option.Name"
    *
@@ -783,6 +861,7 @@ public interface Constants {
    * @since 2.1
    */
   static String PROPERTY_MAPPING_CATALOG = "javax.jdo.mapping.Catalog";
+
   /**
    * Mapping "javax.jdo.mapping.Schema"
    *

--- a/api/src/main/java/javax/jdo/Enhancer.java
+++ b/api/src/main/java/javax/jdo/Enhancer.java
@@ -78,10 +78,13 @@ public class Enhancer {
 
   /** New Line */
   private static final char NL = '\n'; // NOI18N
+
   /** Jar file suffix */
   private static final String JAR_FILE_SUFFIX = ".jar"; // NOI18N
+
   /** JDO Metadata file suffix */
   private static final String JDO_FILE_SUFFIX = ".jdo"; // NOI18N
+
   /** Class file suffix */
   private static final String CLASS_FILE_SUFFIX = ".class"; // NOI18N
 
@@ -92,37 +95,52 @@ public class Enhancer {
 
   /** Error indicator */
   private boolean error = false;
+
   /** If set, process parameters, print usage, and exit. */
   private boolean printAndExit = false;
 
   /** Persistence Units */
   private final List<String> persistenceUnitNames = new ArrayList<>();
+
   /** Target Directory Parameter */
   private String directoryName = null;
+
   /** ClassLoader for JDOEnhancer */
   private ClassLoader loader = null;
+
   /** Classpath (-cp) parameter */
   private String classPath = null;
+
   /** Check Only flag */
   private boolean checkOnly = false;
+
   /** Verbose flag */
   private boolean verbose = false;
+
   /** Recurse flag */
   private boolean recurse = false;
+
   /** Error messages should be empty unless there is an error */
   private final StringBuilder errorBuffer = new StringBuilder();
+
   /** Verbose messages are always collected but only output if verbose flag is set */
   private final StringBuilder verboseBuffer = new StringBuilder();
+
   /** File Names */
   private List<String> fileNames = new ArrayList<>();
+
   /** Class File Names */
   private final List<String> classFileNames = new ArrayList<>();
+
   /** JDO File Names */
   private final List<String> jdoFileNames = new ArrayList<>();
+
   /** Jar File Names */
   private final List<String> jarFileNames = new ArrayList<>();
+
   /** The number of classes validated by the JDOEnhancer */
   private int numberOfValidatedClasses = 0;
+
   /** The number of classes enhanced by the JDOEnhancer */
   private int numberOfEnhancedClasses = 0;
 

--- a/api/src/main/java/javax/jdo/spi/JDOImplHelper.java
+++ b/api/src/main/java/javax/jdo/spi/JDOImplHelper.java
@@ -798,6 +798,7 @@ public class JDOImplHelper extends java.lang.Object {
     String variant = s.substring(secondUnderbar + 1);
     return new Locale(lang, country, variant);
   }
+
   /**
    * Determine if a class is loadable in the current environment.
    *
@@ -992,6 +993,7 @@ public class JDOImplHelper extends java.lang.Object {
     Class<?> getPersistenceCapableSuperclass() {
       return persistenceCapableSuperclass;
     }
+
     /**
      * This is an instance of <code>PersistenceCapable</code>, used at runtime to create new
      * instances.

--- a/exectck/pom.xml
+++ b/exectck/pom.xml
@@ -70,6 +70,12 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <configuration>
+                    <goalPrefix>exectck</goalPrefix>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>

--- a/exectck/src/main/java/org/apache/jdo/exectck/Enhance.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/Enhance.java
@@ -80,6 +80,7 @@ public class Enhance extends AbstractTCKMojo {
         + "inheritance"
         + File.separator
   };
+
   /** Location of TCK generated output. */
   @Parameter(property = "jdo.tck.doEnhance", defaultValue = "true", required = true)
   private boolean doEnhance;

--- a/exectck/src/main/java/org/apache/jdo/exectck/InstallSchema.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/InstallSchema.java
@@ -33,8 +33,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 public class InstallSchema extends AbstractTCKMojo {
 
   private static final String DB_DIR_NAME = "database"; // NOI18N
+
   /** List of mappings required by the current configuration */
   protected Collection<String> mappings = new HashSet<>();
+
   /** Location of TCK generated output. */
   @Parameter(property = "jdo.tck.doInstallSchema", defaultValue = "true", required = true)
   private boolean doInstallSchema;

--- a/exectck/src/main/java/org/apache/jdo/exectck/Utilities.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/Utilities.java
@@ -37,6 +37,7 @@ public class Utilities {
   private Utilities() {
     // This method is deliberately left empty.
   }
+
   /*
    * Return the current date/time as a String.
    */

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>26</version>
+        <version>33</version>
         <relativePath />
     </parent>
 
@@ -166,6 +166,21 @@
         <project.build.outputTimestamp>1661453031</project.build.outputTimestamp>
         <showWarnings></showWarnings>
         <compilerArgument></compilerArgument>
+        <maven.compiler.target>8</maven.compiler.target>
+
+        <version.maven-plugin-api>3.9.9</version.maven-plugin-api>
+        <version.javax.transaction-api>1.3</version.javax.transaction-api>
+        <version.junit-jupiter>5.11.3</version.junit-jupiter>
+        <version.junit-platform>1.11.3</version.junit-platform>
+        <version.javax.persistence>2.2.1</version.javax.persistence>
+        <version.derby>10.14.2.0</version.derby>
+        <version.commons-io>2.17.0</version.commons-io>
+        <version.spring-beans>5.3.39</version.spring-beans>
+        <version.commons-logging>1.2</version.commons-logging>
+        <version.glassfish-corba-omgapi>4.2.5</version.glassfish-corba-omgapi>
+        <version.maven-changes-plugin>2.12.1</version.maven-changes-plugin>
+        <version.maven-bundle-plugin>5.1.9</version.maven-bundle-plugin>
+        <version.fmt-maven-plugin>2.25</version.fmt-maven-plugin>
     </properties>
 
     <dependencyManagement>
@@ -188,79 +203,74 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>3.8.5</version>
+                <version>${version.maven-plugin-api}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>javax.transaction</groupId>
                 <artifactId>javax.transaction-api</artifactId>
-                <version>1.3</version>
+                <version>${version.javax.transaction-api}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.10.0</version>
+                <version>${version.junit-jupiter}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-params</artifactId>
-                <version>5.10.0</version>
+                <version>${version.junit-jupiter}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-suite-api</artifactId>
-                <version>1.10.0</version>
+                <version>${version.junit-platform}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-launcher</artifactId>
-                <version>1.10.0</version>
+                <version>${version.junit-platform}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-console</artifactId>
-                <version>1.10.0</version>
+                <version>${version.junit-platform}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>javax.persistence</artifactId>
-                <version>2.2.1</version>
+                <version>${version.javax.persistence}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
-                <version>10.14.2.0</version>
+                <version>${version.derby}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derbytools</artifactId>
-                <version>10.14.2.0</version>
+                <version>${version.derby}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.14.0</version>
+                <version>${version.commons-io}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-beans</artifactId>
-                <version>5.3.20</version>
+                <version>${version.spring-beans}</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.plugin-tools</groupId>
-                <artifactId>maven-plugin-annotations</artifactId>
-                <version>3.6.4</version>
+                <version>${version.commons-logging}</version>
             </dependency>
             <dependency>
                 <!-- License: EDL 1.0 https://www.eclipse.org/org/documents/edl-v10.php -->
                 <groupId>org.glassfish.corba</groupId>
                 <artifactId>glassfish-corba-omgapi</artifactId>
-                <version>4.2.4</version>
+                <version>${version.glassfish-corba-omgapi}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -270,53 +280,19 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.3.0</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.2.0</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.3.0</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-changes-plugin</artifactId>
-                    <version>2.12.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>${version.maven-changes-plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.6</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.4.0</version>
-                </plugin>
-                <plugin>
-                    <artifactId>org.apache.rat</artifactId>
-                    <version>0.14</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>${version.maven-bundle-plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>com.spotify.fmt</groupId>
                     <artifactId>fmt-maven-plugin</artifactId>
-                    <version>2.19</version>
+                    <version>${version.fmt-maven-plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/tck/src/main/java/org/apache/jdo/tck/api/fetchgroup/FetchGroupTest.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/fetchgroup/FetchGroupTest.java
@@ -67,6 +67,7 @@ public class FetchGroupTest extends JDO_Test {
       new String[] {
         "hiredate", "weeklyhours", "personid", "firstname", "lastname", "middlename", "birthdate"
       };
+
   /** In org/apache/jdo/tck/pc/package.jdo, middlename is not in DFG */
   protected final String[] defaultMembers =
       new String[] {"hiredate", "weeklyhours", "personid", "firstname", "lastname", "birthdate"};
@@ -96,6 +97,7 @@ public class FetchGroupTest extends JDO_Test {
         "phoneNumbers",
         "languages"
       };
+
   /** Address address is of type Address and is a relationship */
   protected final String[] relationshipMembers =
       new String[] {
@@ -113,6 +115,7 @@ public class FetchGroupTest extends JDO_Test {
         "hradvisees",
         "address"
       };
+
   /** Map phoneNumbers and set languages are not relationships but are multivalued */
   protected final String[] multivaluedMembers =
       new String[] {

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanager/detach/DetachSerialize.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanager/detach/DetachSerialize.java
@@ -61,6 +61,7 @@ public class DetachSerialize extends DetachTest {
     byte[] cartStream = serialize(pc);
     return deserialize(cartStream);
   }
+
   /** */
   private byte[] serialize(Object root) {
     try {

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanager/fetchplan/AbstractFetchPlanTest.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanager/fetchplan/AbstractFetchPlanTest.java
@@ -53,6 +53,7 @@ public class AbstractFetchPlanTest extends JDO_Test {
   protected final String[] lowerRightGroup = new String[] {"default", "PCRect.lowerRight"};
   protected final String[] bothGroup =
       new String[] {"default", "PCRect.upperLeft", "PCRect.lowerRight"};
+
   /**
    * @see org.apache.jdo.tck.JDO_Test#localSetUp()
    */

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/SetTransactionIsolationLevel.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/SetTransactionIsolationLevel.java
@@ -138,6 +138,7 @@ public class SetTransactionIsolationLevel extends JDO_Test implements Constants 
     closePMF();
     return;
   }
+
   /** */
   private void getPMFsetTransactionIsolationLevelFromProperties(String level) {
     String property = Constants.PROPERTY_TRANSACTION_ISOLATION_LEVEL + "." + level;

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/JDOConfigListener.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/JDOConfigListener.java
@@ -44,6 +44,7 @@ public class JDOConfigListener extends JDO_Test {
 
   /** Creates a new instance of JDOConfigListener */
   public JDOConfigListener() {}
+
   /** */
   private static final String ASSERTION_FAILED = "Assertions 11.1-40 failed: ";
 

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/Jdoconfig.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/Jdoconfig.java
@@ -38,6 +38,7 @@ public class Jdoconfig extends JDO_Test {
 
   /** Creates a new instance of Jdoconfig */
   public Jdoconfig() {}
+
   /** */
   private static final String ASSERTION_FAILED = "Assertion A11.1.2-1 failed: ";
 

--- a/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/Persistence.java
+++ b/tck/src/main/java/org/apache/jdo/tck/api/persistencemanagerfactory/config/Persistence.java
@@ -41,8 +41,10 @@ public class Persistence extends JDO_Test {
 
   /** Creates a new instance of Jdoconfig */
   public Persistence() {}
+
   /** */
   private static final String ASSERTION_FAILED = "Assertion A11.1.2-1 failed: ";
+
   // Do not use superclass pmf, pm
   private PersistenceManagerFactory pmf = null;
   private PersistenceManager pm = null;

--- a/tck/src/main/java/org/apache/jdo/tck/mapping/Relationship1To1AllRelationships.java
+++ b/tck/src/main/java/org/apache/jdo/tck/mapping/Relationship1To1AllRelationships.java
@@ -362,6 +362,7 @@ public class Relationship1To1AllRelationships extends AbstractRelationshipTest {
       failOnError();
     }
   }
+
   /** */
   @Test
   public void testDeleteFromMappedSide() {

--- a/tck/src/main/java/org/apache/jdo/tck/mapping/RelationshipManyToManyAllRelationships.java
+++ b/tck/src/main/java/org/apache/jdo/tck/mapping/RelationshipManyToManyAllRelationships.java
@@ -296,6 +296,7 @@ public class RelationshipManyToManyAllRelationships extends AbstractRelationship
       failOnError();
     }
   }
+
   /** */
   @Test
   public void testAddExistingFromMappedSide() {
@@ -432,6 +433,7 @@ public class RelationshipManyToManyAllRelationships extends AbstractRelationship
       failOnError();
     }
   }
+
   /** */
   @Test
   public void testDeleteFromMappedSide() {

--- a/tck/src/main/java/org/apache/jdo/tck/pc/company/Employee.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/company/Employee.java
@@ -224,6 +224,7 @@ public abstract class Employee extends Person implements IEmployee {
   public void setDentalInsurance(IDentalInsurance dentalInsurance) {
     this.dentalInsurance = (DentalInsurance) dentalInsurance;
   }
+
   /**
    * Get the medical insurance of the employee.
    *

--- a/tck/src/main/java/org/apache/jdo/tck/pc/company/Person.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/company/Person.java
@@ -379,6 +379,7 @@ public class Person
   public int hashCode() {
     return (int) personid;
   }
+
   /**
    * This class is used to represent the application identifier for the <code>Person</code> class.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedFC/FCAppEmployee.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedFC/FCAppEmployee.java
@@ -267,6 +267,7 @@ public abstract class FCAppEmployee extends FCAppPerson implements IEmployee {
   public void setDentalInsurance(IDentalInsurance dentalInsurance) {
     this.dentalInsurance = (FCAppDentalInsurance) dentalInsurance;
   }
+
   /**
    * Get the medical insurance of the employee.
    *

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedFC/FCAppPerson.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedFC/FCAppPerson.java
@@ -421,6 +421,7 @@ public class FCAppPerson
   public int hashCode() {
     return (int) personid;
   }
+
   /**
    * This class is used to represent the application identifier for the <code>Person</code> class.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedFC/FCDSEmployee.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedFC/FCDSEmployee.java
@@ -264,6 +264,7 @@ public abstract class FCDSEmployee extends FCDSPerson implements IEmployee {
   public void setDentalInsurance(IDentalInsurance dentalInsurance) {
     this.dentalInsurance = (FCDSDentalInsurance) dentalInsurance;
   }
+
   /**
    * Get the medical insurance of the employee.
    *

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedFC/FCDSPerson.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedFC/FCDSPerson.java
@@ -419,6 +419,7 @@ public class FCDSPerson
   public int hashCode() {
     return (int) personid;
   }
+
   /**
    * This class is used to represent the application identifier for the <code>Person</code> class.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedJPA/JPAAppEmployee.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedJPA/JPAAppEmployee.java
@@ -274,6 +274,7 @@ public abstract class JPAAppEmployee extends JPAAppPerson implements IEmployee {
   public void setDentalInsurance(IDentalInsurance dentalInsurance) {
     this.dentalInsurance = (JPAAppDentalInsurance) dentalInsurance;
   }
+
   /**
    * Get the medical insurance of the employee.
    *

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedJPA/JPAAppPerson.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedJPA/JPAAppPerson.java
@@ -466,6 +466,7 @@ public class JPAAppPerson
   public int hashCode() {
     return (int) personid;
   }
+
   /**
    * This class is used to represent the application identifier for the <code>Person</code> class.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedPC/PCAppEmployee.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedPC/PCAppEmployee.java
@@ -246,6 +246,7 @@ public abstract class PCAppEmployee extends PCAppPerson implements IEmployee {
   public void setDentalInsurance(IDentalInsurance dentalInsurance) {
     this._dentalInsurance = (PCAppDentalInsurance) dentalInsurance;
   }
+
   /**
    * Get the medical insurance of the employee.
    *

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedPC/PCAppPerson.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedPC/PCAppPerson.java
@@ -410,6 +410,7 @@ public class PCAppPerson
   public int hashCode() {
     return (int) _personid;
   }
+
   /**
    * This class is used to represent the application identifier for the <code>Person</code> class.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedPC/PCDSPerson.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyAnnotatedPC/PCDSPerson.java
@@ -410,6 +410,7 @@ public class PCDSPerson
   public int hashCode() {
     return (int) _personid;
   }
+
   /**
    * This class is used to represent the application identifier for the <code>Person</code> class.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyListWithoutJoin/Person.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyListWithoutJoin/Person.java
@@ -248,6 +248,7 @@ public class Person
   public int hashCode() {
     return (int) personid;
   }
+
   /**
    * This class is used to represent the application identifier for the <code>Person</code> class.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/pc/companyMapWithoutJoin/Person.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/companyMapWithoutJoin/Person.java
@@ -248,6 +248,7 @@ public class Person
   public int hashCode() {
     return (int) personid;
   }
+
   /**
    * This class is used to represent the application identifier for the <code>Person</code> class.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj.java
+++ b/tck/src/main/java/org/apache/jdo/tck/pc/lifecycle/StateTransitionObj.java
@@ -56,12 +56,14 @@ public class StateTransitionObj implements Serializable {
   public void writeNonmanagedField(int value) {
     nonmanaged_field = value;
   }
+
   /**
    * @return Returns the id.
    */
   public int getId() {
     return id;
   }
+
   /**
    * @param id The id to set.
    */

--- a/tck/src/main/java/org/apache/jdo/tck/query/api/SampleReadQueries.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/api/SampleReadQueries.java
@@ -3577,6 +3577,7 @@ public class SampleReadQueries extends QueryTest {
     public FullTimeEmployee FullTimeEmployee;
 
     public EmpWrapper() {}
+
     // Need constructor to prevent
     // java.lang.NullPointerException
     // at
@@ -3617,6 +3618,7 @@ public class SampleReadQueries extends QueryTest {
     private FullTimeEmployee worker;
 
     public EmpInfo() {}
+
     // Need constructor to prevent
     // java.lang.NullPointerException
     // at
@@ -3670,6 +3672,7 @@ public class SampleReadQueries extends QueryTest {
   protected void tearDown() {
     super.tearDown();
   }
+
   /**
    * @see org.apache.jdo.tck.JDO_Test#localSetUp()
    */

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/RangeAsString.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/RangeAsString.java
@@ -82,6 +82,7 @@ public class RangeAsString extends QueryTest {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)
@@ -157,6 +158,7 @@ public class RangeAsString extends QueryTest {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/methods/SupportedLocalDateMethods.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/methods/SupportedLocalDateMethods.java
@@ -132,6 +132,7 @@ public class SupportedLocalDateMethods extends QueryTest {
   protected void tearDown() {
     super.tearDown();
   }
+
   /**
    * @see org.apache.jdo.tck.JDO_Test#localSetUp()
    */

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/methods/SupportedLocalDateTimeMethods.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/methods/SupportedLocalDateTimeMethods.java
@@ -198,6 +198,7 @@ public class SupportedLocalDateTimeMethods extends QueryTest {
   protected void tearDown() {
     super.tearDown();
   }
+
   /**
    * @see org.apache.jdo.tck.JDO_Test#localSetUp()
    */

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/methods/SupportedLocalTimeMethods.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/methods/SupportedLocalTimeMethods.java
@@ -130,6 +130,7 @@ public class SupportedLocalTimeMethods extends QueryTest {
   protected void tearDown() {
     super.tearDown();
   }
+
   /**
    * @see org.apache.jdo.tck.JDO_Test#localSetUp()
    */

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/methods/SupportedStringMethods.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/methods/SupportedStringMethods.java
@@ -288,6 +288,7 @@ public class SupportedStringMethods extends QueryTest {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/BinarySubtraction.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/BinarySubtraction.java
@@ -120,6 +120,7 @@ public class BinarySubtraction extends QueryTest {
   protected void tearDown() {
     super.tearDown();
   }
+
   /**
    * @see org.apache.jdo.tck.JDO_Test#localSetUp()
    */

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/BitwiseComplement.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/BitwiseComplement.java
@@ -105,6 +105,7 @@ public class BitwiseComplement extends QueryTest {
   protected void tearDown() {
     super.tearDown();
   }
+
   /**
    * @see org.apache.jdo.tck.JDO_Test#localSetUp()
    */

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/ConditionalOR.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/ConditionalOR.java
@@ -92,6 +92,7 @@ public class ConditionalOR extends QueryTest {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)
@@ -123,6 +124,7 @@ public class ConditionalOR extends QueryTest {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/Equality.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/Equality.java
@@ -581,6 +581,7 @@ public class Equality extends ComparisonTests {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/GreaterThan.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/GreaterThan.java
@@ -232,6 +232,7 @@ public class GreaterThan extends ComparisonTests {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/LessThanOrEqual.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/LessThanOrEqual.java
@@ -232,6 +232,7 @@ public class LessThanOrEqual extends ComparisonTests {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)

--- a/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/NotEquals.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/jdoql/operators/NotEquals.java
@@ -254,6 +254,7 @@ public class NotEquals extends ComparisonTests {
       cleanupPM(pm);
     }
   }
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)

--- a/tck/src/main/java/org/apache/jdo/tck/query/result/Unique.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/result/Unique.java
@@ -47,6 +47,7 @@ public class Unique extends QueryTest {
 
   /** */
   private static final String ASSERTION_FAILED = "Assertion A14.6.11-1 (Unique) failed: ";
+
   /** */
   @Test
   @Execution(ExecutionMode.CONCURRENT)

--- a/tck/src/main/java/org/apache/jdo/tck/query/result/classes/PublicLongField.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/result/classes/PublicLongField.java
@@ -27,6 +27,7 @@ public class PublicLongField {
   public PublicLongField(long l) {
     this.l = l;
   }
+
   /**
    * @see Object#hashCode()
    */

--- a/tck/src/main/java/org/apache/jdo/tck/transactions/SetIsolationLevel.java
+++ b/tck/src/main/java/org/apache/jdo/tck/transactions/SetIsolationLevel.java
@@ -35,6 +35,7 @@ public class SetIsolationLevel extends JDO_Test implements Constants {
   /** */
   private static final String ASSERTION_29_FAILED =
       "Assertion A13.4.2-29 (setIsolationLevel) failed: ";
+
   /** */
   private static final String ASSERTION_25_FAILED =
       "Assertion A13.4.2-25 (setIsolationLevel) failed: ";

--- a/tck/src/main/java/org/apache/jdo/tck/util/EqualityHelper.java
+++ b/tck/src/main/java/org/apache/jdo/tck/util/EqualityHelper.java
@@ -97,6 +97,7 @@ public class EqualityHelper {
     }
     return result;
   }
+
   /** Comparator used in method deepEquals comparing maps of DeepEquality. */
   private static class DeepEqualityEntryKeyComparator<K, V> implements Comparator<Map.Entry<K, V>> {
     final Comparator<K> comparator;


### PR DESCRIPTION
This includes updating the JDO parent pom to make use of version 33 of the apache parent pom.
There is a new version of the java code formatter that creates some empty lines to separate declarations, so a number of Java classes are updated.