### PR TITLE
JDO-847: Create sbom files for JDO 3.2.1 release

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -288,6 +288,16 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.4.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.cyclonedx</groupId>
+                    <artifactId>cyclonedx-maven-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.spdx</groupId>
+                    <artifactId>spdx-maven-plugin</artifactId>
+                    <version>0.7.4</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
Checkout branch JDO-847-2 and call mvn cyclonedx:makeBom spdx:createSPDX  to create sbom files using the cyclondx and spdx maven plugins.