### PR TITLE
result.Variable TCK fails

### DIFF
--- a/tck/src/main/java/org/apache/jdo/tck/query/result/Variable.java
+++ b/tck/src/main/java/org/apache/jdo/tck/query/result/Variable.java
@@ -212,7 +212,7 @@ public class Variable extends QueryTest {
   /** */
   @SuppressWarnings("unchecked")
   @Test
-  @Execution(ExecutionMode.CONCURRENT)
+  //@Execution(ExecutionMode.CONCURRENT)
   public void testNoNavigation() {
     List<Employee> expected =
         getTransientCompanyModelInstancesAsList(
@@ -296,7 +296,7 @@ public class Variable extends QueryTest {
   /** */
   @SuppressWarnings("unchecked")
   @Test
-  @Execution(ExecutionMode.CONCURRENT)
+  // @Execution(ExecutionMode.CONCURRENT) TODO fails!
   public void testNavigationWithCompanyAndDepartmentAndEmployeeAndProject() {
     Object expected =
         Arrays.asList(
@@ -352,7 +352,7 @@ public class Variable extends QueryTest {
   /** */
   @SuppressWarnings("unchecked")
   @Test
-  @Execution(ExecutionMode.CONCURRENT)
+  //@Execution(ExecutionMode.CONCURRENT) // TODO this fixed it
   public void testNavigationWithCompanyAndEmployeeAndProject() {
     Object expected =
         Arrays.asList(
@@ -652,7 +652,7 @@ public class Variable extends QueryTest {
   /** */
   @SuppressWarnings("unchecked")
   @Test
-  @Execution(ExecutionMode.CONCURRENT)
+  //@Execution(ExecutionMode.CONCURRENT)
   public void testNavigationWithCompanyConstraint() {
     Object expected =
         Arrays.asList(


### PR DESCRIPTION
Fix for result.Variable see [JDO-851](https://issues.apache.org/jira/projects/JDO/issues/JDO-851).