### PR TITLE
JDO-858: added profile jdori-dn6 to run DataNucleus version 6

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -221,7 +221,7 @@
                 <dependency>
                     <groupId>org.datanucleus</groupId>
                     <artifactId>datanucleus-jdo-query</artifactId>
-                    <version>5.0.9</version>
+                    <version>5.0.10</version>
                 </dependency>
                 <dependency>
                     <groupId>org.datanucleus</groupId>
@@ -256,6 +256,97 @@
                     <version>5.0.0</version>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>jdori-dn6</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>jdo.tck.impl</name>
+                    <value>jdori</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.compiler.target>11</maven.compiler.target>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.datanucleus</groupId>
+                    <artifactId>datanucleus-core</artifactId>
+                    <version>6.0.11</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.datanucleus</groupId>
+                    <artifactId>datanucleus-rdbms</artifactId>
+                    <version>6.0.10</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.datanucleus</groupId>
+                    <artifactId>datanucleus-api-jdo</artifactId>
+                    <version>6.0.5</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.datanucleus</groupId>
+                    <artifactId>datanucleus-jdo-query</artifactId>
+                    <version>6.0.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.datanucleus</groupId>
+                    <artifactId>datanucleus-api-jpa</artifactId>
+                    <version>6.0.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                    <version>2.25.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                    <version>2.25.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-jcl</artifactId>
+                    <version>2.25.3</version>
+                </dependency>
+                <dependency>
+                    <!-- License: CDDL + GPLv2 with classpath exception https://github.com/javaee/javax.annotation/blob/master/LICENSE -->
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+                <dependency>
+                    <!-- License: EDL 1.0 https://www.eclipse.org/org/documents/edl-v10.php -->
+                    <groupId>org.glassfish.corba</groupId>
+                    <artifactId>glassfish-corba-orb</artifactId>
+                    <version>5.0.0</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                    <!-- This plugin makes sure to run the profile with a JDK 11 or above -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-versions</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>[11,)</version>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -221,7 +221,7 @@
                 <dependency>
                     <groupId>org.datanucleus</groupId>
                     <artifactId>datanucleus-jdo-query</artifactId>
-                    <version>5.0.10</version>
+                    <version>5.0.9</version>
                 </dependency>
                 <dependency>
                     <groupId>org.datanucleus</groupId>
@@ -256,97 +256,6 @@
                     <version>5.0.0</version>
                 </dependency>
             </dependencies>
-        </profile>
-        <profile>
-            <id>jdori-dn6</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>jdo.tck.impl</name>
-                    <value>jdori</value>
-                </property>
-            </activation>
-            <properties>
-                <maven.compiler.target>11</maven.compiler.target>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.datanucleus</groupId>
-                    <artifactId>datanucleus-core</artifactId>
-                    <version>6.0.11</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.datanucleus</groupId>
-                    <artifactId>datanucleus-rdbms</artifactId>
-                    <version>6.0.10</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.datanucleus</groupId>
-                    <artifactId>datanucleus-api-jdo</artifactId>
-                    <version>6.0.5</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.datanucleus</groupId>
-                    <artifactId>datanucleus-jdo-query</artifactId>
-                    <version>6.0.2</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.datanucleus</groupId>
-                    <artifactId>datanucleus-api-jpa</artifactId>
-                    <version>6.0.2</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                    <version>2.25.3</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                    <version>2.25.3</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-jcl</artifactId>
-                    <version>2.25.3</version>
-                </dependency>
-                <dependency>
-                    <!-- License: CDDL + GPLv2 with classpath exception https://github.com/javaee/javax.annotation/blob/master/LICENSE -->
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                </dependency>
-                <dependency>
-                    <!-- License: EDL 1.0 https://www.eclipse.org/org/documents/edl-v10.php -->
-                    <groupId>org.glassfish.corba</groupId>
-                    <artifactId>glassfish-corba-orb</artifactId>
-                    <version>5.0.0</version>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                    <!-- This plugin makes sure to run the profile with a JDK 11 or above -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-versions</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <requireJavaVersion>
-                                            <version>[11,)</version>
-                                        </requireJavaVersion>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
There are two profiles in the tck submodule:

- jdori runs DataNucleus 5 and ist activated by default
- jdori-dn6 runs DataNucleus 6 and may be started calling mvn clean install -Pjdori-dn6
