### PR TITLE
JDO-823: Fix sonarcloud issues of type Code Smells

### DIFF
--- a/api/src/main/java/javax/jdo/Enhancer.java
+++ b/api/src/main/java/javax/jdo/Enhancer.java
@@ -368,8 +368,8 @@ public class Enhancer {
    *
    * If the recursion flag is set, directories contained in directories are examined, recursively.
    */
-  private void parseFiles(
-      String[] fileNames, boolean search, boolean recurse) { // NOSONAR Cognitive Complexity
+  private void parseFiles( // NOSONAR Cognitive Complexity
+      String[] fileNames, boolean search, boolean recurse) {
     for (String fileName : fileNames) {
       if (fileName.endsWith(JAR_FILE_SUFFIX)) {
         // add to jar file names

--- a/api/src/main/java/javax/jdo/Enhancer.java
+++ b/api/src/main/java/javax/jdo/Enhancer.java
@@ -195,32 +195,8 @@ public class Enhancer {
               (String) entry.getValue());
         }
       }
-      enhancer.setVerbose(verbose);
-      if (loader != null) {
-        enhancer.setClassLoader(loader);
-      }
+      setEnhancerProperties(enhancer);
 
-      int numberOfClasses = classFileNames.size();
-      if (numberOfClasses != 0) {
-        enhancer.addClasses(classFileNames.toArray(new String[numberOfClasses]));
-      }
-      int numberOfFiles = jdoFileNames.size();
-      if (numberOfFiles != 0) {
-        enhancer.addFiles(jdoFileNames.toArray(new String[numberOfFiles]));
-      }
-      if (!jarFileNames.isEmpty()) {
-        for (String jarFileName : jarFileNames) {
-          enhancer.addJar(jarFileName);
-        }
-      }
-      if (persistenceUnitNames != null) {
-        for (String persistenceUnitName : persistenceUnitNames) {
-          enhancer.addPersistenceUnit(persistenceUnitName);
-        }
-      }
-      if (directoryName != null) {
-        enhancer.setOutputDirectory(directoryName);
-      }
       if (checkOnly) {
         numberOfValidatedClasses = enhancer.validate();
         addVerboseMessage("MSG_EnhancerValidatedClasses", numberOfValidatedClasses); // NOI18N
@@ -255,11 +231,45 @@ public class Enhancer {
   }
 
   /**
+   * Set the properties of the JDOEnhancer.
+   *
+   * @param enhancer the enhancer insatance
+   */
+  private void setEnhancerProperties(JDOEnhancer enhancer) {
+    enhancer.setVerbose(verbose);
+    if (loader != null) {
+      enhancer.setClassLoader(loader);
+    }
+
+    int numberOfClasses = classFileNames.size();
+    if (numberOfClasses != 0) {
+      enhancer.addClasses(classFileNames.toArray(new String[numberOfClasses]));
+    }
+    int numberOfFiles = jdoFileNames.size();
+    if (numberOfFiles != 0) {
+      enhancer.addFiles(jdoFileNames.toArray(new String[numberOfFiles]));
+    }
+    if (!jarFileNames.isEmpty()) {
+      for (String jarFileName : jarFileNames) {
+        enhancer.addJar(jarFileName);
+      }
+    }
+    if (persistenceUnitNames != null) {
+      for (String persistenceUnitName : persistenceUnitNames) {
+        enhancer.addPersistenceUnit(persistenceUnitName);
+      }
+    }
+    if (directoryName != null) {
+      enhancer.setOutputDirectory(directoryName);
+    }
+  }
+
+  /**
    * Parse the command line arguments. Put the results into fields.
    *
    * @param args the command line arguments
    */
-  private void parseArgs(String[] args) {
+  private void parseArgs(String[] args) { // NOSONAR Cognitive Complexity
     boolean doneWithOptions = false;
     fileNames = new ArrayList<>();
     for (int i = 0; i < args.length; ++i) {
@@ -358,7 +368,8 @@ public class Enhancer {
    *
    * If the recursion flag is set, directories contained in directories are examined, recursively.
    */
-  private void parseFiles(String[] fileNames, boolean search, boolean recurse) {
+  private void parseFiles(
+      String[] fileNames, boolean search, boolean recurse) { // NOSONAR Cognitive Complexity
     for (String fileName : fileNames) {
       if (fileName.endsWith(JAR_FILE_SUFFIX)) {
         // add to jar file names

--- a/api/src/main/java/javax/jdo/JDOException.java
+++ b/api/src/main/java/javax/jdo/JDOException.java
@@ -208,33 +208,7 @@ public class JDOException extends java.lang.RuntimeException {
     // include failed object information
     if (failed != null) {
       sb.append("\n").append(MSG.msg("MSG_FailedObject"));
-      String failedToString = null;
-      try {
-        failedToString = failed.toString();
-      } catch (Exception ex) {
-        // include the information from the exception thrown by failed.toString
-        Object objectId = JDOHelper.getObjectId(failed);
-        if (objectId == null) {
-          failedToString =
-              MSG.msg(
-                  "MSG_ExceptionGettingFailedToString", // NOI18N
-                  exceptionToString(ex));
-        } else {
-          // include the ObjectId information
-          String objectIdToString = null;
-          try {
-            objectIdToString = objectId.toString();
-          } catch (Exception ex2) {
-            objectIdToString = exceptionToString(ex2);
-          }
-          failedToString =
-              MSG.msg(
-                  "MSG_ExceptionGettingFailedToStringObjectId", // NOI18N
-                  exceptionToString(ex),
-                  objectIdToString);
-        }
-      }
-      sb.append(failedToString);
+      sb.append(failedToString());
     }
     // include nested Throwable information, but only if not called by
     // printStackTrace; the stacktrace will include the cause anyway.
@@ -315,5 +289,35 @@ public class JDOException extends java.lang.RuntimeException {
     String s = ex.getClass().getName();
     String message = ex.getMessage();
     return (message != null) ? (s + ": " + message) : s;
+  }
+
+  private String failedToString() {
+    String failedToString = null;
+    try {
+      failedToString = failed.toString();
+    } catch (Exception ex) {
+      // include the information from the exception thrown by failed.toString
+      Object objectId = JDOHelper.getObjectId(failed);
+      if (objectId == null) {
+        failedToString =
+            MSG.msg(
+                "MSG_ExceptionGettingFailedToString", // NOI18N
+                exceptionToString(ex));
+      } else {
+        // include the ObjectId information
+        String objectIdToString = null;
+        try {
+          objectIdToString = objectId.toString();
+        } catch (Exception ex2) {
+          objectIdToString = exceptionToString(ex2);
+        }
+        failedToString =
+            MSG.msg(
+                "MSG_ExceptionGettingFailedToStringObjectId", // NOI18N
+                exceptionToString(ex),
+                objectIdToString);
+      }
+    }
+    return failedToString;
   }
 }

--- a/api/src/main/java/javax/jdo/JDOHelper.java
+++ b/api/src/main/java/javax/jdo/JDOHelper.java
@@ -744,7 +744,7 @@ public class JDOHelper implements Constants {
     try {
       while ((line = reader.readLine()) != null) {
         line = line.trim();
-        if (line.length() == 0 || line.startsWith("#")) {
+        if (line.isEmpty() || line.startsWith("#")) {
           continue;
         }
         // else assume first line of text is the PMF class name
@@ -1580,7 +1580,7 @@ public class JDOHelper implements Constants {
     Enumeration<URL> urls = null;
     try {
       urls = getResources(loader, Constants.SERVICE_LOOKUP_ENHANCER_RESOURCE_NAME);
-    } catch (Throwable ex) {
+    } catch (Exception ex) {
       exceptions.add(ex);
     }
 
@@ -1591,7 +1591,7 @@ public class JDOHelper implements Constants {
           String enhancerClassName = getClassNameFromURL(urls.nextElement());
           Class<?> enhancerClass = forName(enhancerClassName, true, ctrLoader);
           return (JDOEnhancer) enhancerClass.newInstance();
-        } catch (Throwable ex) {
+        } catch (Exception ex) {
           // remember exceptions from failed enhancer invocations
           exceptions.add(ex);
         }

--- a/api/src/main/java/javax/jdo/spi/I18NHelper.java
+++ b/api/src/main/java/javax/jdo/spi/I18NHelper.java
@@ -80,7 +80,7 @@ public class I18NHelper {
   private I18NHelper(String bundleName, ClassLoader loader) {
     try {
       bundle = loadBundle(bundleName, loader);
-    } catch (Throwable e) {
+    } catch (Exception e) {
       failure = e;
     }
   }

--- a/api/src/main/java/javax/jdo/spi/JDOImplHelper.java
+++ b/api/src/main/java/javax/jdo/spi/JDOImplHelper.java
@@ -1066,7 +1066,7 @@ public class JDOImplHelper extends java.lang.Object {
       StateInterrogation si = sit.next();
       try {
         if (si.makeDirty(pc, fieldName)) return;
-      } catch (Throwable t) {
+      } catch (Exception t) {
         // ignore exceptions from errant StateInterrogations
       }
     }
@@ -1091,7 +1091,7 @@ public class JDOImplHelper extends java.lang.Object {
       Boolean result;
       try {
         result = sibr.is(pc, si);
-      } catch (Throwable t) {
+      } catch (Exception t) {
         continue; // ignore exceptions from errant StateInterrogations
       }
       if (result != null) return result.booleanValue();
@@ -1117,7 +1117,7 @@ public class JDOImplHelper extends java.lang.Object {
       Object result;
       try {
         result = sibr.get(pc, si);
-      } catch (Throwable t) {
+      } catch (Exception t) {
         continue; // ignore exceptions from errant StateInterrogations
       }
       if (result != null) return result;

--- a/api/src/test/java/javax/jdo/MockEnhancer.java
+++ b/api/src/test/java/javax/jdo/MockEnhancer.java
@@ -55,7 +55,9 @@ public class MockEnhancer implements JDOEnhancer {
   @SuppressWarnings("unused")
   private String outputDirectory = null;
 
-  public MockEnhancer() {}
+  public MockEnhancer() {
+    // This method body is intentionally left blank
+  }
 
   public Properties getProperties() {
     return props;
@@ -130,6 +132,7 @@ public class MockEnhancer implements JDOEnhancer {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
+  @Override
   public byte[] transform(
       ClassLoader loader,
       String className,

--- a/api/src/test/java/javax/jdo/PMFProxy.java
+++ b/api/src/test/java/javax/jdo/PMFProxy.java
@@ -26,13 +26,11 @@ public class PMFProxy implements InvocationHandler {
   private String connectionDriverName;
 
   public static PersistenceManagerFactory newInstance() {
-    PersistenceManagerFactory pmf =
-        (PersistenceManagerFactory)
-            Proxy.newProxyInstance(
-                PMFProxy.class.getClassLoader(),
-                new Class[] {PersistenceManagerFactory.class},
-                new PMFProxy());
-    return pmf;
+    return (PersistenceManagerFactory)
+        Proxy.newProxyInstance(
+            PMFProxy.class.getClassLoader(),
+            new Class[] {PersistenceManagerFactory.class},
+            new PMFProxy());
   }
 
   /*

--- a/api/src/test/java/javax/jdo/PMFService.java
+++ b/api/src/test/java/javax/jdo/PMFService.java
@@ -21,7 +21,9 @@ import java.util.Map;
 /** */
 public class PMFService implements Constants {
 
-  public PMFService() {}
+  public PMFService() {
+    // This method body is intentionally left blank
+  }
 
   public static PersistenceManagerFactory getPersistenceManagerFactory(
       Map<?, ?> overrides, Map<?, ?> props) {

--- a/api/src/test/java/javax/jdo/annotations/Line.java
+++ b/api/src/test/java/javax/jdo/annotations/Line.java
@@ -26,7 +26,9 @@ package javax.jdo.annotations;
 public class Line {
 
   /** Creates a new instance of Line */
-  public Line() {}
+  public Line() {
+    // This method body is intentionally left blank
+  }
 
   Point point1;
   Point point2;

--- a/api/src/test/java/javax/jdo/annotations/Point.java
+++ b/api/src/test/java/javax/jdo/annotations/Point.java
@@ -26,7 +26,9 @@ package javax.jdo.annotations;
 public class Point {
 
   /** Creates a new instance of Point */
-  public Point() {}
+  public Point() {
+    // This method body is intentionally left blank
+  }
 
   int x;
   Integer y;

--- a/api/src/test/java/javax/jdo/identity/ByteIdentityTest.java
+++ b/api/src/test/java/javax/jdo/identity/ByteIdentityTest.java
@@ -30,8 +30,11 @@ import org.junit.jupiter.api.Test;
 class ByteIdentityTest extends SingleFieldIdentityTest {
 
   /** Creates a new instance of ByteIdentityTest */
-  public ByteIdentityTest() {}
+  public ByteIdentityTest() {
+    // This method body is intentionally left blank
+  }
 
+  @Override
   @Test
   void testConstructor() {
     ByteIdentity c1 = new ByteIdentity(Object.class, (byte) 1);
@@ -76,6 +79,7 @@ class ByteIdentityTest extends SingleFieldIdentityTest {
         "No exception caught for illegal String.");
   }
 
+  @Override
   @Test
   void testSerialized() {
     ByteIdentity c1 = new ByteIdentity(Object.class, (byte) 1);

--- a/api/src/test/java/javax/jdo/identity/CharIdentityTest.java
+++ b/api/src/test/java/javax/jdo/identity/CharIdentityTest.java
@@ -32,8 +32,11 @@ import org.junit.jupiter.api.Test;
 class CharIdentityTest extends SingleFieldIdentityTest {
 
   /** Creates a new instance of CharIdentityTest */
-  public CharIdentityTest() {}
+  public CharIdentityTest() {
+    // This method body is intentionally left blank
+  }
 
+  @Override
   @Test
   void testConstructor() {
     CharIdentity c1 = new CharIdentity(Object.class, 'a');
@@ -84,6 +87,7 @@ class CharIdentityTest extends SingleFieldIdentityTest {
         "No exception caught for String too short.");
   }
 
+  @Override
   @Test
   void testSerialized() {
     CharIdentity c1 = new CharIdentity(Object.class, 'a');

--- a/api/src/test/java/javax/jdo/identity/ConcreteTestIdentity.java
+++ b/api/src/test/java/javax/jdo/identity/ConcreteTestIdentity.java
@@ -53,10 +53,12 @@ public class ConcreteTestIdentity extends SingleFieldIdentity<ConcreteTestIdenti
     throw new UnsupportedOperationException("Not implemented");
   }
 
+  @Override
   public void writeExternal(ObjectOutput out) throws IOException {
     super.writeExternal(out);
   }
 
+  @Override
   public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
     super.readExternal(in);
   }

--- a/api/src/test/java/javax/jdo/identity/IntIdentityTest.java
+++ b/api/src/test/java/javax/jdo/identity/IntIdentityTest.java
@@ -30,8 +30,11 @@ import org.junit.jupiter.api.Test;
 class IntIdentityTest extends SingleFieldIdentityTest {
 
   /** Creates a new instance of IntIdentityTest */
-  public IntIdentityTest() {}
+  public IntIdentityTest() {
+    // This method body is intentionally left blank
+  }
 
+  @Override
   @Test
   void testConstructor() {
     IntIdentity c1 = new IntIdentity(Object.class, 1);
@@ -74,6 +77,7 @@ class IntIdentityTest extends SingleFieldIdentityTest {
         "No exception caught for illegal String.");
   }
 
+  @Override
   @Test
   void testSerialized() {
     IntIdentity c1 = new IntIdentity(Object.class, 1);

--- a/api/src/test/java/javax/jdo/identity/LongIdentityTest.java
+++ b/api/src/test/java/javax/jdo/identity/LongIdentityTest.java
@@ -30,8 +30,11 @@ import org.junit.jupiter.api.Test;
 class LongIdentityTest extends SingleFieldIdentityTest {
 
   /** Creates a new instance of LongIdentityTest */
-  public LongIdentityTest() {}
+  public LongIdentityTest() {
+    // This method body is intentionally left blank
+  }
 
+  @Override
   @Test
   void testConstructor() {
     LongIdentity c1 = new LongIdentity(Object.class, 1);
@@ -76,6 +79,7 @@ class LongIdentityTest extends SingleFieldIdentityTest {
         "No exception caught for illegal String.");
   }
 
+  @Override
   @Test
   void testSerialized() {
     LongIdentity c1 = new LongIdentity(Object.class, 1);

--- a/api/src/test/java/javax/jdo/identity/ObjectIdentityTest.java
+++ b/api/src/test/java/javax/jdo/identity/ObjectIdentityTest.java
@@ -58,8 +58,11 @@ class ObjectIdentityTest extends SingleFieldIdentityTest {
   }
 
   /** Creates a new instance of ObjectIdentityTest */
-  public ObjectIdentityTest() {}
+  public ObjectIdentityTest() {
+    // This method body is intentionally left blank
+  }
 
+  @Override
   @Test
   void testConstructor() {
     ObjectIdentity c1 = new ObjectIdentity(Object.class, new IdClass(1));

--- a/api/src/test/java/javax/jdo/identity/ShortIdentityTest.java
+++ b/api/src/test/java/javax/jdo/identity/ShortIdentityTest.java
@@ -30,8 +30,11 @@ import org.junit.jupiter.api.Test;
 class ShortIdentityTest extends SingleFieldIdentityTest {
 
   /** Creates a new instance of ShortIdentityTest */
-  public ShortIdentityTest() {}
+  public ShortIdentityTest() {
+    // This method body is intentionally left blank
+  }
 
+  @Override
   @Test
   void testConstructor() {
     ShortIdentity c1 = new ShortIdentity(Object.class, (short) 1);
@@ -74,6 +77,7 @@ class ShortIdentityTest extends SingleFieldIdentityTest {
         "No exception caught for illegal String.");
   }
 
+  @Override
   @Test
   void testSerialized() {
     ShortIdentity c1 = new ShortIdentity(Object.class, (short) 1);

--- a/api/src/test/java/javax/jdo/identity/SingleFieldIdentityTest.java
+++ b/api/src/test/java/javax/jdo/identity/SingleFieldIdentityTest.java
@@ -42,7 +42,9 @@ class SingleFieldIdentityTest extends AbstractTest {
   Object scti3;
 
   /** Creates a new instance of SingleFieldIdentityTest */
-  public SingleFieldIdentityTest() {}
+  public SingleFieldIdentityTest() {
+    // This method body is intentionally left blank
+  }
 
   @Test
   void testConstructor() {

--- a/api/src/test/java/javax/jdo/identity/StringIdentityTest.java
+++ b/api/src/test/java/javax/jdo/identity/StringIdentityTest.java
@@ -30,8 +30,11 @@ import org.junit.jupiter.api.Test;
 class StringIdentityTest extends SingleFieldIdentityTest {
 
   /** Creates a new instance of StringIdentityTest */
-  public StringIdentityTest() {}
+  public StringIdentityTest() {
+    // This method body is intentionally left blank
+  }
 
+  @Override
   @Test
   void testConstructor() {
     StringIdentity c1 = new StringIdentity(Object.class, "1");
@@ -48,6 +51,7 @@ class StringIdentityTest extends SingleFieldIdentityTest {
     Assertions.assertEquals(c1, c2, "Equal StringIdentity instances compare not equal.");
   }
 
+  @Override
   @Test
   void testSerialized() {
     StringIdentity c1 = new StringIdentity(Object.class, "1");

--- a/api/src/test/java/javax/jdo/listener/InstanceLifecycleEventTest.java
+++ b/api/src/test/java/javax/jdo/listener/InstanceLifecycleEventTest.java
@@ -44,7 +44,9 @@ class InstanceLifecycleEventTest extends AbstractTest {
   final Object detachTarget = new Object();
 
   /** Creates a new instance of SingleFieldIdentityTest */
-  public InstanceLifecycleEventTest() {}
+  public InstanceLifecycleEventTest() {
+    // This method body is intentionally left blank
+  }
 
   @Test
   void testConstructorCreateEvent() {

--- a/api/src/test/java/javax/jdo/pc/PCPoint.java
+++ b/api/src/test/java/javax/jdo/pc/PCPoint.java
@@ -36,9 +36,9 @@ public class PCPoint implements PersistenceCapable {
   protected transient StateManager jdoStateManager;
   protected transient byte jdoFlags;
   private static final int jdoInheritedFieldCount = 0;
-  private static final String jdoFieldNames[] = {"x", "y"};
-  private static final Class<?> jdoFieldTypes[];
-  private static final byte jdoFieldFlags[] = {
+  private static final String[] jdoFieldNames = {"x", "y"};
+  private static final Class<?>[] jdoFieldTypes;
+  private static final byte[] jdoFieldFlags = {
     (byte)
         (PersistenceCapable.CHECK_READ
             + PersistenceCapable.CHECK_WRITE
@@ -63,7 +63,9 @@ public class PCPoint implements PersistenceCapable {
   }
 
   /** JDO required no-args constructor. */
-  public PCPoint() {}
+  public PCPoint() {
+    // This method body is intentionally left blank
+  }
 
   /** Constructor. */
   public PCPoint(int x, Integer y) {
@@ -198,13 +200,13 @@ public class PCPoint implements PersistenceCapable {
     if (statemanager != null) jdoFlags = statemanager.replacingFlags(this);
   }
 
-  public final void jdoReplaceFields(int fields[]) {
+  public final void jdoReplaceFields(int[] fields) {
     if (fields == null) throw new IllegalArgumentException("fields is null");
     int i = fields.length;
     for (int j = 0; j < i; j++) jdoReplaceField(fields[j]);
   }
 
-  public final void jdoProvideFields(int fields[]) {
+  public final void jdoProvideFields(int[] fields) {
     if (fields == null) throw new IllegalArgumentException("fields is null");
     int i = fields.length;
     for (int j = 0; j < i; j++) jdoProvideField(fields[j]);
@@ -219,14 +221,22 @@ public class PCPoint implements PersistenceCapable {
   // that declare objectid-class in xml metadata:
 
   public void jdoCopyKeyFieldsToObjectId(
-      PersistenceCapable.ObjectIdFieldSupplier objectidfieldsupplier, Object obj) {}
+      PersistenceCapable.ObjectIdFieldSupplier objectidfieldsupplier, Object obj) {
+    // This method body is intentionally left blank
+  }
 
-  public void jdoCopyKeyFieldsToObjectId(Object obj) {}
+  public void jdoCopyKeyFieldsToObjectId(Object obj) {
+    // This method body is intentionally left blank
+  }
 
   public void jdoCopyKeyFieldsFromObjectId(
-      PersistenceCapable.ObjectIdFieldConsumer objectidfieldconsumer, Object obj) {}
+      PersistenceCapable.ObjectIdFieldConsumer objectidfieldconsumer, Object obj) {
+    // This method body is intentionally left blank
+  }
 
-  protected void jdoCopyKeyFieldsFromObjectId(Object obj) {}
+  protected void jdoCopyKeyFieldsFromObjectId(Object obj) {
+    // This method body is intentionally left blank
+  }
 
   public Object jdoNewObjectIdInstance() {
     return null;
@@ -321,8 +331,9 @@ public class PCPoint implements PersistenceCapable {
           y = (Integer) statemanager.replacingObjectField(this, field);
           return;
         }
+      default:
+        throw new IllegalArgumentException("field number out of range");
     }
-    throw new IllegalArgumentException("field number out of range");
   }
 
   public void jdoProvideField(int field) {
@@ -342,11 +353,12 @@ public class PCPoint implements PersistenceCapable {
           statemanager.providedObjectField(this, field, y);
           return;
         }
+      default:
+        throw new IllegalArgumentException("field number out of range");
     }
-    throw new IllegalArgumentException("field number out of range");
   }
 
-  public void jdoCopyFields(Object obj, int fieldNumbers[]) {
+  public void jdoCopyFields(Object obj, int[] fieldNumbers) {
     if (jdoStateManager == null) throw new IllegalStateException("jdoStateManager is null");
     if (!(obj instanceof PCPoint)) throw new ClassCastException(obj.getClass().getName());
     if (fieldNumbers == null) throw new IllegalArgumentException("fieldNumber is null");
@@ -373,8 +385,9 @@ public class PCPoint implements PersistenceCapable {
           y = pcpoint.y;
           return;
         }
+      default:
+        throw new IllegalArgumentException("field number out of range");
     }
-    throw new IllegalArgumentException("field number out of range");
   }
 
   private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {

--- a/api/src/test/java/javax/jdo/spi/StateInterrogationTest.java
+++ b/api/src/test/java/javax/jdo/spi/StateInterrogationTest.java
@@ -45,7 +45,9 @@ class StateInterrogationTest extends AbstractTest {
   private final JDOImplHelper implHelper = JDOImplHelper.getInstance();
 
   /** Creates a new instance of StateInterrogationTest */
-  public StateInterrogationTest() {}
+  public StateInterrogationTest() {
+    // This method body is intentionally left blank
+  }
 
   @Test
   void testGetObjectIdNull() {

--- a/api/src/test/java/javax/jdo/stub/StubPMF.java
+++ b/api/src/test/java/javax/jdo/stub/StubPMF.java
@@ -332,31 +332,57 @@ public class StubPMF implements PersistenceManagerFactory, Constants {
   public DataStoreCache getDataStoreCache() {
     return new DataStoreCache() {
 
-      public void evict(Object oid) {}
+      public void evict(Object oid) {
+        // This method body is intentionally left blank
+      }
 
-      public void evictAll() {}
+      public void evictAll() {
+        // This method body is intentionally left blank
+      }
 
-      public void evictAll(Object... oids) {}
+      public void evictAll(Object... oids) {
+        // This method body is intentionally left blank
+      }
 
-      public void evictAll(Collection<?> oids) {}
+      public void evictAll(Collection<?> oids) {
+        // This method body is intentionally left blank
+      }
 
-      public void evictAll(boolean subclasses, Class<?> pcClass) {}
+      public void evictAll(boolean subclasses, Class<?> pcClass) {
+        // This method body is intentionally left blank
+      }
 
-      public void pin(Object oid) {}
+      public void pin(Object oid) {
+        // This method body is intentionally left blank
+      }
 
-      public void pinAll(Collection<?> oids) {}
+      public void pinAll(Collection<?> oids) {
+        // This method body is intentionally left blank
+      }
 
-      public void pinAll(Object... oids) {}
+      public void pinAll(Object... oids) {
+        // This method body is intentionally left blank
+      }
 
-      public void pinAll(boolean subclasses, Class<?> pcClass) {}
+      public void pinAll(boolean subclasses, Class<?> pcClass) {
+        // This method body is intentionally left blank
+      }
 
-      public void unpin(Object oid) {}
+      public void unpin(Object oid) {
+        // This method body is intentionally left blank
+      }
 
-      public void unpinAll(Collection<?> oids) {}
+      public void unpinAll(Collection<?> oids) {
+        // This method body is intentionally left blank
+      }
 
-      public void unpinAll(Object... oids) {}
+      public void unpinAll(Object... oids) {
+        // This method body is intentionally left blank
+      }
 
-      public void unpinAll(boolean subclasses, Class<?> pcClass) {}
+      public void unpinAll(boolean subclasses, Class<?> pcClass) {
+        // This method body is intentionally left blank
+      }
     };
   }
 

--- a/api/src/test/java/javax/jdo/util/XMLTestUtil.java
+++ b/api/src/test/java/javax/jdo/util/XMLTestUtil.java
@@ -317,34 +317,34 @@ public class XMLTestUtil {
 
     /** Return the error location for the file under test. */
     private String getErrorLocation(int lineNumber, int columnNumber) {
-      String[] lines = getLines();
-      int length = lines.length;
+      String[] linesArray = getLines();
+      int length = linesArray.length;
       if (lineNumber > length) {
         return "Line number "
             + lineNumber
-            + " exceeds the number of lines in the file ("
-            + lines.length
+            + " exceeds the number of linesArray in the file ("
+            + linesArray.length
             + ")";
       } else if (lineNumber < 1) {
         return "Line number " + lineNumber + " does not allow retriving the error location.";
       }
       StringBuffer buf = new StringBuffer();
       if (lineNumber > 2) {
-        buf.append(lines[lineNumber - 3]);
+        buf.append(linesArray[lineNumber - 3]);
         buf.append(NL);
-        buf.append(lines[lineNumber - 2]);
+        buf.append(linesArray[lineNumber - 2]);
         buf.append(NL);
       }
-      buf.append(lines[lineNumber - 1]);
+      buf.append(linesArray[lineNumber - 1]);
       buf.append(NL);
       for (int i = 1; i < columnNumber; ++i) {
         buf.append(' ');
       }
       buf.append("^\n");
       if (lineNumber + 1 < length) {
-        buf.append(lines[lineNumber]);
+        buf.append(linesArray[lineNumber]);
         buf.append(NL);
-        buf.append(lines[lineNumber + 1]);
+        buf.append(linesArray[lineNumber + 1]);
         buf.append(NL);
       }
       return buf.toString();
@@ -493,7 +493,7 @@ public class XMLTestUtil {
   private static String[] checkMetadataSystemProperty() {
     String[] ret = null;
     String metadata = System.getProperty(METADATA_PROP);
-    if ((metadata != null) && (metadata.length() > 0)) {
+    if ((metadata != null) && (!metadata.isEmpty())) {
       List<String> entries = new ArrayList<>();
       StringTokenizer st = new StringTokenizer(metadata, DELIM);
       while (st.hasMoreTokens()) {

--- a/exectck/src/main/java/org/apache/jdo/exectck/PropertyUtils.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/PropertyUtils.java
@@ -56,7 +56,8 @@ public class PropertyUtils {
       String confName = confDir + File.separator + cfg;
       if (!new File(confName).exists()) {
         // Conf file nor found => continue
-        System.out.println("ERROR: Configuration file " + confName + " not found.");
+        System.out.println(
+            "ERROR: Configuration file " + confName + " not found."); // NOSONAR System.out
         continue;
       }
 

--- a/exectck/src/main/java/org/apache/jdo/exectck/PropertyUtils.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/PropertyUtils.java
@@ -56,8 +56,8 @@ public class PropertyUtils {
       String confName = confDir + File.separator + cfg;
       if (!new File(confName).exists()) {
         // Conf file nor found => continue
-        System.out.println(
-            "ERROR: Configuration file " + confName + " not found."); // NOSONAR System.out
+        System.out.println( // NOSONAR System.out
+            "ERROR: Configuration file " + confName + " not found.");
         continue;
       }
 

--- a/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
@@ -257,8 +257,8 @@ public class RunTCK extends AbstractTCKMojo {
           String confFileName = confDirectory + FS + cfg;
           if (!new File(confFileName).exists()) {
             // Conf file nor found => continue
-            System.out.println(
-                "ERROR: Configuration file " + confFileName + " not found."); // NOSONAR System.out
+            System.out.println( // NOSONAR System.out
+                "ERROR: Configuration file " + confFileName + " not found.");
             continue;
           }
           Properties props = PropertyUtils.getProperties(confDirectory + FS + cfg);
@@ -268,8 +268,8 @@ public class RunTCK extends AbstractTCKMojo {
           }
           List<String> classesList = getTestClasses(props, cfg, excludeFile);
           if (classesList.isEmpty()) {
-            System.out.println(
-                "Skipping configuration " + cfg + ": classes excluded"); // NOSONAR System.out
+            System.out.println( // NOSONAR System.out
+                "Skipping configuration " + cfg + ": classes excluded");
             continue;
           }
 
@@ -607,8 +607,8 @@ public class RunTCK extends AbstractTCKMojo {
       if (runtckVerbose) {
         System.out.println("\nCommand line is: \n" + command.toString()); // NOSONAR System.out
         System.out.println("Test exit value is " + resultValue); // NOSONAR System.out
-        System.out.println(
-            "Test result output:\n" + fileToString(junitLogFilename)); // NOSONAR System.out
+        System.out.println( // NOSONAR System.out
+            "Test result output:\n" + fileToString(junitLogFilename));
       }
     } catch (java.lang.RuntimeException re) {
       System.out.println("Exception on command " + command); // NOSONAR System.out
@@ -628,8 +628,8 @@ public class RunTCK extends AbstractTCKMojo {
       File logFile = new File(implLogFile);
       FileUtils.moveFile(logFile, new File(testLogFilename));
     } catch (Exception e) {
-      System.out.println(
-          ">> Error moving implementation log file: " + e.getMessage()); // NOSONAR System.out
+      System.out.println( // NOSONAR System.out
+          ">> Error moving implementation log file: " + e.getMessage());
     }
     String tckLogFilename = logFilePrefix + TCK_LOG_FILE;
     try {

--- a/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/RunTCK.java
@@ -187,7 +187,7 @@ public class RunTCK extends AbstractTCKMojo {
   @Override
   public void execute() throws MojoExecutionException {
     if (!doRunTCK) {
-      System.out.println("Skipping RunTCK goal!");
+      System.out.println("Skipping RunTCK goal!"); // NOSONAR System.out
       return;
     }
 
@@ -257,7 +257,8 @@ public class RunTCK extends AbstractTCKMojo {
           String confFileName = confDirectory + FS + cfg;
           if (!new File(confFileName).exists()) {
             // Conf file nor found => continue
-            System.out.println("ERROR: Configuration file " + confFileName + " not found.");
+            System.out.println(
+                "ERROR: Configuration file " + confFileName + " not found."); // NOSONAR System.out
             continue;
           }
           Properties props = PropertyUtils.getProperties(confDirectory + FS + cfg);
@@ -267,7 +268,8 @@ public class RunTCK extends AbstractTCKMojo {
           }
           List<String> classesList = getTestClasses(props, cfg, excludeFile);
           if (classesList.isEmpty()) {
-            System.out.println("Skipping configuration " + cfg + ": classes excluded");
+            System.out.println(
+                "Skipping configuration " + cfg + ": classes excluded"); // NOSONAR System.out
             continue;
           }
 
@@ -343,7 +345,7 @@ public class RunTCK extends AbstractTCKMojo {
 
     PropertyUtils.string2Collection(dblist, dbs);
     PropertyUtils.string2Collection(identitytypes, idtypes);
-    System.out.println(
+    System.out.println( // NOSONAR System.out
         "*>TCK to be run for implementation '"
             + impl
             + "' on \n"
@@ -357,7 +359,7 @@ public class RunTCK extends AbstractTCKMojo {
             + identitytypes);
 
     // Properties required for test execution
-    System.out.println("cleanupaftertest is " + cleanupaftertest);
+    System.out.println("cleanupaftertest is " + cleanupaftertest); // NOSONAR System.out
 
     List<String> propsString = new ArrayList<>();
     propsString.add("-Dverbose=" + verbose);
@@ -408,7 +410,7 @@ public class RunTCK extends AbstractTCKMojo {
       URL url1 = enhancedDir.toURI().toURL();
       URL url2 = new File(buildDirectory + FS + CLASSES_DIR_NAME + FS).toURI().toURL();
       if (runtckVerbose) {
-        System.out.println("url2 is " + url2.toString());
+        System.out.println("url2 is " + url2.toString()); // NOSONAR System.out
       }
       cpList.add(url1);
       cpList.add(url2);
@@ -426,7 +428,7 @@ public class RunTCK extends AbstractTCKMojo {
     }
     cpString = Utilities.urls2ClasspathString(cpList);
     if (runtckVerbose) {
-      System.out.println("\nClasspath is " + cpString);
+      System.out.println("\nClasspath is " + cpString); // NOSONAR System.out
     }
     return cpString;
   }
@@ -532,7 +534,7 @@ public class RunTCK extends AbstractTCKMojo {
    * @param logFilePrefix
    * @return
    */
-  private int executeTestClass(
+  private int executeTestClass( // NOSONAR Methods should not have too many parameters
       String cpString,
       List<String> cfgPropsString,
       List<String> classesList,
@@ -570,18 +572,18 @@ public class RunTCK extends AbstractTCKMojo {
     // add Test classes
     for (String testClass : classesList) {
       // skip empty entries
-      if (testClass != null && testClass.trim().length() > 0) {
+      if (testClass != null && !testClass.trim().isEmpty()) {
         command.add("-c");
         command.add(testClass);
       }
     }
 
     if (debugTCK) {
-      System.out.println("Using debug arguments: \n" + debugDirectives);
+      System.out.println("Using debug arguments: \n" + debugDirectives); // NOSONAR System.out
     }
 
     // invoke class runner
-    System.out.print(
+    System.out.print( // NOSONAR System.out
         "*> Running tests for "
             + cfg
             + " with "
@@ -598,17 +600,18 @@ public class RunTCK extends AbstractTCKMojo {
     try {
       resultValue = Utilities.invokeCommand(command, new File(buildDirectory), junitLogFilename);
       if (resultValue == 0) {
-        System.out.println("success");
+        System.out.println("success"); // NOSONAR System.out
       } else {
-        System.out.println("FAIL");
+        System.out.println("FAIL"); // NOSONAR System.out
       }
       if (runtckVerbose) {
-        System.out.println("\nCommand line is: \n" + command.toString());
-        System.out.println("Test exit value is " + resultValue);
-        System.out.println("Test result output:\n" + fileToString(junitLogFilename));
+        System.out.println("\nCommand line is: \n" + command.toString()); // NOSONAR System.out
+        System.out.println("Test exit value is " + resultValue); // NOSONAR System.out
+        System.out.println(
+            "Test result output:\n" + fileToString(junitLogFilename)); // NOSONAR System.out
       }
     } catch (java.lang.RuntimeException re) {
-      System.out.println("Exception on command " + command);
+      System.out.println("Exception on command " + command); // NOSONAR System.out
     }
     return resultValue;
   }
@@ -625,14 +628,15 @@ public class RunTCK extends AbstractTCKMojo {
       File logFile = new File(implLogFile);
       FileUtils.moveFile(logFile, new File(testLogFilename));
     } catch (Exception e) {
-      System.out.println(">> Error moving implementation log file: " + e.getMessage());
+      System.out.println(
+          ">> Error moving implementation log file: " + e.getMessage()); // NOSONAR System.out
     }
     String tckLogFilename = logFilePrefix + TCK_LOG_FILE;
     try {
       File logFile = new File(tckLogFile);
       FileUtils.moveFile(logFile, new File(tckLogFilename));
     } catch (Exception e) {
-      System.out.println(">> Error moving tck log file: " + e.getMessage());
+      System.out.println(">> Error moving tck log file: " + e.getMessage()); // NOSONAR System.out
     }
   }
 
@@ -653,12 +657,12 @@ public class RunTCK extends AbstractTCKMojo {
     try {
       FileUtils.forceDeleteOnExit(new File(implLogFile));
     } catch (Exception e) {
-      System.out.println(">> Error deleting log file: " + e.getMessage());
+      System.out.println(">> Error deleting log file: " + e.getMessage()); // NOSONAR System.out
     }
     try {
       FileUtils.forceDeleteOnExit(new File(TCK_LOG_FILE));
     } catch (Exception e) {
-      System.out.println(">> Error deleting log file: " + e.getMessage());
+      System.out.println(">> Error deleting log file: " + e.getMessage()); // NOSONAR System.out
     }
 
     // Output results
@@ -670,7 +674,7 @@ public class RunTCK extends AbstractTCKMojo {
     command.add("org.apache.jdo.tck.util.ResultSummary");
     command.add(logDir);
     Utilities.invokeCommand(command, new File(buildDirectory), resultSummaryLogFile);
-    System.out.println(fileToString(resultSummaryLogFile));
+    System.out.println(fileToString(resultSummaryLogFile)); // NOSONAR System.out
 
     // Create system configuration description file
     command.set(3, "org.apache.jdo.tck.util.SystemCfgSummary");
@@ -678,6 +682,17 @@ public class RunTCK extends AbstractTCKMojo {
     command.add("system_config.txt");
     Utilities.invokeCommand(command, new File(buildDirectory), null);
 
+    copyMetadata(cfgDirName);
+
+    if (TCK_PARAM_ON_FAILURE_FAIL_FAST.equals(onFailure) && failureCount > 0) {
+      throw new MojoExecutionException("Aborted TCK test run after 1 failure.");
+    }
+    if (TCK_PARAM_ON_FAILURE_FAIL_EVENTUALLY.equals(onFailure) && failureCount > 0) {
+      throw new MojoExecutionException("There were " + failureCount + " TCK test failures.");
+    }
+  }
+
+  private void copyMetadata(String cfgDirName) throws MojoExecutionException {
     // Copy metadata from enhanced to configuration logs directory
     for (String idtype : idtypes) {
       String fromDirName = buildDirectory + FS + "enhanced" + FS + impl + FS + idtype + FS;
@@ -705,13 +720,6 @@ public class RunTCK extends AbstractTCKMojo {
           }
         }
       }
-    }
-
-    if (TCK_PARAM_ON_FAILURE_FAIL_FAST.equals(onFailure) && failureCount > 0) {
-      throw new MojoExecutionException("Aborted TCK test run after 1 failure.");
-    }
-    if (TCK_PARAM_ON_FAILURE_FAIL_EVENTUALLY.equals(onFailure) && failureCount > 0) {
-      throw new MojoExecutionException("There were " + failureCount + " TCK test failures.");
     }
   }
 

--- a/exectck/src/main/java/org/apache/jdo/exectck/SQLFileLoader.java
+++ b/exectck/src/main/java/org/apache/jdo/exectck/SQLFileLoader.java
@@ -132,7 +132,7 @@ public class SQLFileLoader {
    * @return the next non comment character
    * @throws IOException If an I/O error occurs
    */
-  private int next() throws IOException {
+  private int next() throws IOException { // NOSONAR Cognitive Complexity
     int result = this.nextChar;
     switch (this.nextChar) {
       case '\'':


### PR DESCRIPTION
- Methods should not be empty
- "@Override" should be used on overriding and implementing methods
-  Cognitive Complexity of methods should not be too high
-  Array designators "[]" should be on the type, not the variable
-  Standard outputs should not be used directly to log anything
-  Throwable and Error should not be caught
-  "String.isEmpty()" should be used to test for emptiness
-  "switch" statements should have "default" clauses
-  Local variables should not be declared and then immediately returned or thrown
-  Local variables should not shadow class fields
-  Methods should not have too many parameters