### PR TITLE
Update RAT excludes file path to work across all submodules

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -356,6 +356,9 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludesFile>${maven.multiModuleProjectDirectory}/.rat-excludes</excludesFile>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
-                    <excludesFile>.rat-excludes</excludesFile>
+                    <excludesFile>${maven.multiModuleProjectDirectory}/.rat-excludes</excludesFile>
                 </configuration>
             </plugin>
             <!-- Release -->


### PR DESCRIPTION
Use \${maven.multiModuleProjectDirectory} to reference .rat-excludes from the project root so all submodules pick up the excludes configuration, not just the root module.

## Summary                                                                                                                                                                                                      
                  
  The `.rat-excludes` file at the project root was only being picked up by
  the root module. Submodules were ignoring it because the relative path                                                                                                                                          
  `.rat-excludes` resolved to each submodule's own basedir, where no such
  file exists.                                                                                                                                                                                                    
                                                                                                                                                                                                                  
  Fix by using `${maven.multiModuleProjectDirectory}` to reference the                                                                                                                                            
  excludes file from the project root in both `pom.xml` and                                                                                                                                                       
  `parent-pom/pom.xml`, so all submodules consistently use the same
  excludes list.                                                                                                                                                                                                  
                                                                                                                                                                                                                  
  This ensures the `META-INF/services/*` and other exclusions added in                                                                                                                                            
  #123 are honoured when running `apache-rat:check` across all modules.              