### PR TITLE
Update JDOHelper.java to resolve security issue

### DIFF
--- a/api/src/main/java/javax/jdo/JDOHelper.java
+++ b/api/src/main/java/javax/jdo/JDOHelper.java
@@ -1153,7 +1153,7 @@ public class JDOHelper implements Constants {
     factory.setNamespaceAware(true);
     factory.setValidating(false);
     factory.setIgnoringElementContentWhitespace(true);
-    factory.setExpandEntityReferences(true);
+    factory.setExpandEntityReferences(false);
 
     return factory;
   }


### PR DESCRIPTION
Change the getDefaultDocumentBuilderFactory xml handling to disable ExpandEntityReferences
This is a suggestion by a security scan initiated by Tilmann.